### PR TITLE
chore: pin ruff==0.15.5 — unified version across all CI

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install "ruff==0.15.5" mypy
 
       - name: Ruff (lint)
         run: ruff check . --output-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install Linting Tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install "ruff==0.15.5" mypy
 
       - name: Run Ruff Linter
         run: |

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ruff mypy pydantic pyyaml
+          pip install "ruff==0.15.5" mypy pydantic pyyaml
 
       - name: Check for banned files
         run: |

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff mypy pydantic pydantic-settings
+      - run: pip install "ruff==0.15.5" mypy pydantic pydantic-settings
       - run: ruff check . && ruff format --check .
       - run: mypy engine/ --strict --ignore-missing-imports 2>/dev/null || true
 

--- a/.github/workflows/refactoring-validation.yml
+++ b/.github/workflows/refactoring-validation.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy pytest pytest-xdist pytest-cov
+          pip install "ruff==0.15.5" mypy pytest pytest-xdist pytest-cov
 
       - name: Run Ruff Linter (BLOCKING)
         run: |

--- a/engine/config/loader.py
+++ b/engine/config/loader.py
@@ -109,9 +109,7 @@ class DomainPackLoader:
         try:
             candidate.relative_to(self._base_path.resolve())
         except ValueError as exc:
-            raise DomainNotFoundError(
-                f"Invalid domain path: {domain_id!r} resolves outside base directory"
-            ) from exc
+            raise DomainNotFoundError(f"Invalid domain path: {domain_id!r} resolves outside base directory") from exc
 
         if not candidate.exists():
             raise DomainNotFoundError(f"Domain spec not found: {candidate}")

--- a/engine/handlers.py
+++ b/engine/handlers.py
@@ -232,7 +232,8 @@ def _sanitize_expression(expr: str) -> str:
     _check_dangerous_patterns(expr_stripped, expr_lower)
 
     has_safe_function = any(
-        expr_lower.startswith(f.lower()) or f" {f.lower()}" in expr_lower or f"({f.lower()}" in expr_lower for f in _SAFE_CYPHER_FUNCTIONS
+        expr_lower.startswith(f.lower()) or f" {f.lower()}" in expr_lower or f"({f.lower()}" in expr_lower
+        for f in _SAFE_CYPHER_FUNCTIONS
     )
     # Only allow direct property references (n.<identifier>), not function calls that wrap
     # property access (e.g. substring(n.name, 0, 3) is rejected here).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pytest = "^8.3.0"
 pytest-asyncio = "^1.3.0"
 pytest-cov = "^7.0.0"
 pytest-mock = "^3.14.0"
-ruff = "^0.15.4"
+ruff = "==0.15.5"
 mypy = "^1.13.0"
 faker = "^40.5.1"
 testcontainers = {extras = ["neo4j"], version = "^4.8.0"}


### PR DESCRIPTION
## Summary

Pins ruff to exactly `0.15.5` across the entire repo to eliminate version drift between CI jobs.

## Changes

**Workflow files** (all `pip install ruff` → `pip install "ruff==0.15.5"`)
- `.github/workflows/ci-quality.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/compliance.yml`
- `.github/workflows/contracts.yml`
- `.github/workflows/refactoring-validation.yml`

**pyproject.toml**
- `ruff = "^0.15.4"` → `ruff = "==0.15.5"`

**Reformatted by ruff 0.15.5**
- `engine/config/loader.py`
- `engine/handlers.py`

## Why

A pinned exact version ensures every CI step and local dev environment uses the same formatter, preventing formatting drift between ruff minor releases.