### PR TITLE
chore: standardize all tool versions — ruff 0.15.5, pytest 8.3.5, mypy 1.14.0, py312

### DIFF
--- a/.github/workflows/auto-fix-adr.yml
+++ b/.github/workflows/auto-fix-adr.yml
@@ -42,13 +42,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: develop
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install linters
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install ruff==0.15.5 mypy==1.14.0
 
       - name: Ruff (lint)
         run: ruff check . --output-format=github
@@ -130,14 +130,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e . 2>/dev/null || pip install -r requirements.txt 2>/dev/null || true
-          pip install pytest pytest-cov
+          pip install pytest==8.3.5 pytest-cov==6.0.0
 
       - name: Run tests with coverage
         run: pytest tests/ --cov=. --cov-report=xml --cov-report=term --ignore=tests/e2e || true
         continue-on-error: true
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -217,7 +217,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e . 2>/dev/null || pip install -r requirements.txt 2>/dev/null || true
-          pip install pytest pytest-asyncio pytest-cov httpx
+          pip install pytest==8.3.5 pytest-asyncio pytest-cov==6.0.0 httpx
           # Install any project-specific test deps
           if [ -n "${{ vars.TEST_EXTRA_DEPS }}" ]; then
             pip install ${{ vars.TEST_EXTRA_DEPS }}
@@ -231,7 +231,7 @@ jobs:
         run: pytest tests/ -v --cov=. --cov-report=xml --cov-report=term --ignore=tests/e2e
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -115,10 +115,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -126,7 +126,7 @@ jobs:
       - name: Install Linting Tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install ruff==0.15.5 mypy==1.14.0
 
       - name: Run Ruff Linter
         run: |
@@ -189,10 +189,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -205,7 +205,7 @@ jobs:
           else
             echo "⚠️  No requirements file found at ${{ env.REQUIREMENTS_FILE }}"
           fi
-          pip install pytest pytest-cov pytest-xdist pytest-asyncio pytest-timeout
+          pip install pytest==8.3.5 pytest-cov==6.0.0 pytest-xdist pytest-asyncio pytest-timeout
 
       - name: Run Tests with Coverage
         env:
@@ -225,7 +225,7 @@ jobs:
           echo "✅ All tests passed with coverage >=${{ env.COVERAGE_THRESHOLD }}%"
 
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@15f84a87bdc039a8af98c1a9e12c153c15c1d773v5.1.2
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           flags: unittests
@@ -246,12 +246,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -259,7 +259,7 @@ jobs:
       - name: Install Security Tools
         run: |
           python -m pip install --upgrade pip
-          pip install pip-audit safety bandit
+          pip install pip-audit==2.9.0 safety bandit==1.9.0
 
       - name: Run Gitleaks (Secret Detection)
         uses: gitleaks/gitleaks-action@v2
@@ -306,7 +306,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Generate Software Bill of Materials
         uses: anchore/sbom-action@fc46e51fb0e4e3ecf1ea2be3b2e00ee50f1c4e44v0.17.7
@@ -331,7 +331,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -343,7 +343,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@a57c67b89589d2d13d5ac85a9fc4679e7539e94cv3.27.9
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: scorecard.sarif
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,15 +42,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@a57c67b89589d2d13d5ac85a9fc4679e7539e94cv3.27.9
+        uses: github/codeql-action/init@v3
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@a57c67b89589d2d13d5ac85a9fc4679e7539e94cv3.27.9
+        uses: github/codeql-action/analyze@v3
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # END OF CODEQL ANALYSIS

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ruff mypy pydantic pyyaml
+          pip install ruff==0.15.5 mypy==1.14.0 pydantic pyyaml
 
       - name: Check for banned files
         run: |

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff mypy pydantic pydantic-settings
+      - run: pip install ruff==0.15.5 mypy==1.14.0 pydantic pydantic-settings
       - run: ruff check . && ruff format --check .
       - run: mypy engine/ --strict --ignore-missing-imports 2>/dev/null || true
 
@@ -58,5 +58,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -e ".[dev]" 2>/dev/null || pip install pytest
+      - run: pip install -e ".[dev]" 2>/dev/null || pip install pytest==8.3.5
       - run: pytest tests/ -v --tb=short 2>/dev/null || echo "No tests or pytest skipped"

--- a/.github/workflows/dev-layer-gmp.yml
+++ b/.github/workflows/dev-layer-gmp.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -55,7 +55,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-asyncio
+          pip install pytest==8.3.5 pytest-cov==6.0.0 pytest-asyncio
 
       - name: Run Dev Layer Tests
         run: |
@@ -67,7 +67,7 @@ jobs:
             -v
 
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@15f84a87bdc039a8af98c1a9e12c153c15c1d773v5.1.2
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           flags: dev-layer

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cfv3.2.0
@@ -124,7 +124,7 @@ jobs:
 
       - name: Scan Image with Trivy
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@6248b7a39d00dc24b36616b6dfb1c3c78e4dfe91v0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: sarif
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload Trivy Results to Security Tab
         if: always() && github.event_name != 'pull_request'
-        uses: github/codeql-action/upload-sarif@a57c67b89589d2d13d5ac85a9fc4679e7539e94cv3.27.9
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
 

--- a/.github/workflows/docs-code-sync.yml
+++ b/.github/workflows/docs-code-sync.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814v4.2.0

--- a/.github/workflows/pr-review-enforcement.yml
+++ b/.github/workflows/pr-review-enforcement.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Load Configuration
         id: config
@@ -65,7 +65,7 @@ jobs:
           echo "max_files=${{ vars.PR_MAX_FILES || '' }}${MAX_FILES}" | sed 's/[^0-9].*//' >> $GITHUB_OUTPUT
 
       - name: Check PR Size and Policies
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdeav7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/refactoring-validation.yml
+++ b/.github/workflows/refactoring-validation.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -57,7 +57,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy pytest pytest-xdist pytest-cov
+          pip install ruff==0.15.5 mypy==1.14.0 pytest==8.3.5 pytest-xdist pytest-cov==6.0.0
 
       - name: Run Ruff Linter (BLOCKING)
         run: |

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -71,7 +71,7 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard Results to Security Tab
-        uses: github/codeql-action/upload-sarif@a57c67b89589d2d13d5ac85a9fc4679e7539e94cv3.27.9
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: scorecard.sarif
 
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Review Dependencies
         uses: actions/dependency-review-action@5aa4f05ee5e9f4f33e5c31e13d7d77c6a07a86e2v4.5.0
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Generate SBOM with Syft
         uses: anchore/sbom-action@fc46e51fb0e4e3ecf1ea2be3b2e00ee50f1c4e44v0.17.7
@@ -149,10 +149,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2bv5.3.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/.github/workflows/terminology-guard.yml
+++ b/.github/workflows/terminology-guard.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11v4.1.1
+        uses: actions/checkout@v4
 
       - name: Check Forbidden Terms
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Code formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.5
     hooks:
       - id: ruff
         args: [--fix]
@@ -97,7 +97,7 @@ repos:
 
   # YAML validation
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
         args: [--allow-multiple-documents]

--- a/engine/config/loader.py
+++ b/engine/config/loader.py
@@ -109,9 +109,7 @@ class DomainPackLoader:
         try:
             candidate.relative_to(self._base_path.resolve())
         except ValueError as exc:
-            raise DomainNotFoundError(
-                f"Invalid domain path: {domain_id!r} resolves outside base directory"
-            ) from exc
+            raise DomainNotFoundError(f"Invalid domain path: {domain_id!r} resolves outside base directory") from exc
 
         if not candidate.exists():
             raise DomainNotFoundError(f"Domain spec not found: {candidate}")

--- a/engine/handlers.py
+++ b/engine/handlers.py
@@ -232,7 +232,8 @@ def _sanitize_expression(expr: str) -> str:
     _check_dangerous_patterns(expr_stripped, expr_lower)
 
     has_safe_function = any(
-        expr_lower.startswith(f.lower()) or f" {f.lower()}" in expr_lower or f"({f.lower()}" in expr_lower for f in _SAFE_CYPHER_FUNCTIONS
+        expr_lower.startswith(f.lower()) or f" {f.lower()}" in expr_lower or f"({f.lower()}" in expr_lower
+        for f in _SAFE_CYPHER_FUNCTIONS
     )
     # Only allow direct property references (n.<identifier>), not function calls that wrap
     # property access (e.g. substring(n.name, 0, 3) is rejected here).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "engine"}]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 fastapi = "^0.135.1"
 uvicorn = {extras = ["standard"], version = "^0.41.0"}
 neo4j = "^5.25.0"
@@ -22,12 +22,12 @@ prometheus-client = "^0.24.1"
 numpy = "^1.26.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.0"
+pytest = "8.3.5"
 pytest-asyncio = "^1.3.0"
-pytest-cov = "^7.0.0"
+pytest-cov = "6.0.0"
 pytest-mock = "^3.14.0"
-ruff = "^0.15.4"
-mypy = "^1.13.0"
+ruff = "0.15.5"
+mypy = "1.14.0"
 faker = "^40.5.1"
 testcontainers = {extras = ["neo4j"], version = "^4.8.0"}
 
@@ -61,7 +61,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
@@ -119,7 +119,7 @@ ignore = [
 "engine/config/**" = ["S105"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true              # catch untyped returns (harvested from L9 Kernel)
 warn_unused_configs = true
 warn_unreachable = true             # catch dead code paths (harvested from L9 Kernel)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,13 +3,13 @@
 
 -r requirements.txt
 
-pytest>=8.3.0,<9.0.0
+pytest==8.3.5
 pytest-asyncio>=1.3.0,<2.0.0
-pytest-cov>=7.0.0,<8.0.0
+pytest-cov==6.0.0
 pytest-mock>=3.14.0,<4.0.0
 pytest-xdist>=3.5.0,<4.0.0
 pytest-timeout>=2.3.0,<3.0.0
-ruff>=0.15.4,<1.0.0
-mypy>=1.13.0,<2.0.0
+ruff==0.15.5
+mypy==1.14.0
 faker>=40.5.1,<41.0.0
 testcontainers[neo4j]>=4.8.0,<5.0.0


### PR DESCRIPTION
## Version Standardization Sweep

### Python Packages — exact pins across all `pip install` calls in CI

| Package | Before | After |
|---------|--------|-------|
| ruff | unversioned/^0.15.4 | `0.15.5` |
| mypy | unversioned/^1.13.0 | `1.14.0` |
| pytest | ^8.3.0 | `8.3.5` |
| pytest-cov | ^7.0.0 | `6.0.0` |
| bandit | unversioned | `1.9.0` |
| pip-audit | unversioned | `2.9.0` |

### pyproject.toml
- `python = "^3.12"` (was ^3.11)
- `[tool.ruff] target-version = "py312"` (was py311)
- `[tool.mypy] python_version = "3.12"` (was 3.11)
- Dev dep pins: ruff==0.15.5, mypy==1.14.0, pytest==8.3.5, pytest-cov==6.0.0

### .pre-commit-config.yaml
- ruff-pre-commit: `v0.15.5` (was v0.15.4)
- pre-commit-hooks: `v4.5.0` (was v5.0.0)
- mirrors-mypy: `v1.14.0` (unchanged, already correct)

### requirements-dev.txt
- Exact pins for ruff, mypy, pytest, pytest-cov

### GitHub Actions — all 14 workflow files
- `actions/checkout` → `@v4`
- `actions/setup-python` → `@v5`
- `actions/upload-artifact` → `@v4`
- `actions/github-script` → `@v7`
- `codecov/codecov-action` → `@v5`
- `aquasecurity/trivy-action` → `@0.35.0`
- `SonarSource/sonarcloud-github-action` → `SonarSource/sonarqube-scan-action@v6`
- `github/codeql-action/*` → `@v3`

### ruff format
- 2 Python files reformatted (`engine/config/loader.py`, `engine/handlers.py`)

---
*Generated by L9 Agent — version standardization sweep*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated Python minimum version requirement to 3.12
  - Pinned development and testing tool versions for reproducibility
  - Updated GitHub Actions workflow references to stable versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->