### PR TITLE
fix(gap-9): deprecate inference_bridge v1 — hard ImportError with migration path to DerivationGraph

### DIFF
--- a/engine/inference_bridge.py
+++ b/engine/inference_bridge.py
@@ -1,0 +1,25 @@
+"""
+--- L9_META ---
+l9_schema: 1
+origin: gap-fix
+engine: graph
+layer: [inference]
+tags: [deprecated, guard, v1, bridge]
+owner: engine-team
+status: deprecated
+--- /L9_META ---
+
+engine/inference_bridge.py
+
+GAP-9 FIX: Guard against silent use of inference_bridge.py (v1).
+Any direct import of the v1 bridge now raises ImportError with a
+migration path pointing to inference_bridge_v2.py (DAG engine).
+
+This file REPLACES the v1 bridge.
+"""
+raise ImportError(
+    "engine.inference_bridge (v1) is deprecated and disabled. "
+    "It bypasses the DerivationGraph DAG engine, causing inference to fire outside "
+    "the topological sort order with no unlock-value targeting. "
+    "Migrate all callers to: from engine.inference_bridge_v2 import DerivationGraph"
+)


### PR DESCRIPTION
## Gap 9

**File:** `engine/inference_bridge.py`

Hard deprecation guard. Raises `ImportError` on any import of the v1 bridge.

**Why:** v1 fires inference outside topological sort order with no unlock-value targeting — bypasses the DerivationGraph DAG engine entirely.

**Migration path in error message:**
```
from engine.inference_bridge_v2 import DerivationGraph
```

**Find remaining callers:**
```bash
grep -r 'from engine.inference_bridge import\|import engine.inference_bridge' --include='*.py'
```