### PR TITLE
feat: GRAPH-side Redis Streams adapter — closes bidirectional ENRICH↔GRAPH loop

### DIFF
--- a/chassis/errors.py
+++ b/chassis/errors.py
@@ -103,8 +103,8 @@ class ExecutionError(ChassisError):
     status_code: int = 500
 
 
-class FeatureNotEnabled(ChassisError):
-    """Feature gate is off — operator must opt in via env/settings → HTTP 422.
+class FeatureNotEnabled(ChassisError):  # noqa: N818
+    """Feature gate is off - operator must opt in via env/settings -> HTTP 422.
 
     Raised instead of NotImplementedError for dormant features that have
     working implementations but are gated behind a feature flag.

--- a/engine/adapters/redis_stream_adapter.py
+++ b/engine/adapters/redis_stream_adapter.py
@@ -1,0 +1,93 @@
+"""
+redis_stream_adapter.py — GRAPH repo
+Stream publish adapter for GRAPH → ENRICH bidirectional loop.
+
+Publishes graph.inference.complete events after every materialization batch
+so the EIE GraphInferenceConsumer can feed inferred triples back into
+the convergence loop.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import redis.asyncio as aioredis
+
+from engine.config.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+GRAPH_INFERENCE_STREAM = "graph.inference.complete"
+STREAM_MAXLEN = 50_000  # keep last 50k events, approximate trim
+
+
+class RedisStreamAdapter:
+    """Async Redis Streams adapter for GRAPH-side event publishing."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client: aioredis.Redis | None = None
+
+    async def connect(self) -> None:
+        redis_url = getattr(self._settings, "redis_url", "redis://localhost:6379/0")
+        self._client = aioredis.from_url(
+            redis_url, encoding="utf-8", decode_responses=True
+        )
+        logger.info("redis_stream_adapter_connected", extra={"url": redis_url})
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    async def publish_inference_event(
+        self,
+        entity_id: str,
+        domain: str,
+        run_id: str,
+        inferred_triples: list[dict[str, Any]],
+        materialization_pass: int = 1,
+        graph_confidence: float = 0.0,
+    ) -> str | None:
+        """
+        Publish a graph.inference.complete event to Redis Streams.
+
+        Returns the stream message ID on success, None on failure
+        (failures are non-fatal — ENRICH degrades gracefully without signals).
+        """
+        if self._client is None:
+            logger.warning("redis_not_connected_skipping_publish")
+            return None
+
+        try:
+            payload = json.dumps({
+                "entity_id": entity_id,
+                "domain": domain,
+                "run_id": run_id,
+                "inferred_triples": inferred_triples,
+                "materialization_pass": materialization_pass,
+                "graph_confidence": graph_confidence,
+            })
+            msg_id = await self._client.xadd(
+                GRAPH_INFERENCE_STREAM,
+                {"payload": payload},
+                maxlen=STREAM_MAXLEN,
+                approximate=True,
+            )
+            logger.debug(
+                "inference_event_published",
+                extra={
+                    "stream": GRAPH_INFERENCE_STREAM,
+                    "entity_id": entity_id,
+                    "triples": len(inferred_triples),
+                    "msg_id": msg_id,
+                },
+            )
+            return msg_id
+        except Exception as exc:
+            logger.warning(
+                "inference_event_publish_failed",
+                extra={"entity_id": entity_id, "error": str(exc)},
+            )
+            return None

--- a/engine/adapters/redis_stream_adapter.py
+++ b/engine/adapters/redis_stream_adapter.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any
 
 import redis.asyncio as aioredis
+from redis.exceptions import RedisError
 
 from engine.config.settings import Settings
 
@@ -75,6 +76,13 @@ class RedisStreamAdapter:
                 maxlen=STREAM_MAXLEN,
                 approximate=True,
             )
+        except RedisError as exc:
+            logger.warning(
+                "inference_event_publish_failed",
+                extra={"entity_id": entity_id, "error": str(exc)},
+            )
+            return None
+        else:
             logger.debug(
                 "inference_event_published",
                 extra={
@@ -85,9 +93,3 @@ class RedisStreamAdapter:
                 },
             )
             return msg_id
-        except Exception as exc:
-            logger.warning(
-                "inference_event_publish_failed",
-                extra={"entity_id": entity_id, "error": str(exc)},
-            )
-            return None

--- a/engine/arbitration/engine.py
+++ b/engine/arbitration/engine.py
@@ -24,7 +24,9 @@ class ArbitrationEngine:
             - (data.risk * weights.risk)
             + (data.capacity * weights.capacity)
         )
-        spread = max(data.revenue, data.margin, data.risk, data.capacity) - min(data.revenue, data.margin, data.risk, data.capacity)
+        spread = max(data.revenue, data.margin, data.risk, data.capacity) - min(
+            data.revenue, data.margin, data.risk, data.capacity
+        )
 
         if composite >= policy.thresholds.approve_threshold:
             state = "approve"

--- a/engine/arbitration/schema.py
+++ b/engine/arbitration/schema.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
-
 DecisionState = Literal["approve", "reject", "defer", "escalate"]
 
 
@@ -18,7 +17,7 @@ class ArbitrationInput(BaseModel):
     compliance_pass: bool
 
     @model_validator(mode="after")
-    def validate_ranges(self) -> "ArbitrationInput":
+    def validate_ranges(self) -> ArbitrationInput:
         for field_name in ("revenue", "margin", "risk", "capacity"):
             value = getattr(self, field_name)
             if value < 0.0 or value > 1.0:

--- a/engine/auth/capabilities.py
+++ b/engine/auth/capabilities.py
@@ -31,7 +31,7 @@ import logging
 import secrets
 import time
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -184,14 +184,12 @@ class CapabilityValidator:
             return False
         if not capability.is_active():
             return False
-        if capability.tenant_id != tenant and capability.tenant_id != "*":
+        if capability.tenant_id not in {tenant, "*"}:
             return False
         if action not in capability.allowed_actions:
             return False
         registered = self._registry.get(capability.capability_id)
-        if registered is None or registered.revoked:
-            return False
-        return True
+        return not (registered is None or registered.revoked)
 
     def derive_capability(
         self,
@@ -209,7 +207,7 @@ class CapabilityValidator:
 
         # Monotonicity: domain
         child_domain = scope_restriction.get("domain_id", parent.domain_id)
-        if parent.domain_id != "*" and child_domain != parent.domain_id:
+        if parent.domain_id not in {"*", child_domain}:
             msg = (
                 f"Monotonicity violation: parent domain '{parent.domain_id}' "
                 f"cannot derive child domain '{child_domain}'"
@@ -218,13 +216,12 @@ class CapabilityValidator:
 
         # Monotonicity: actions
         child_actions_raw = scope_restriction.get("allowed_actions", parent.allowed_actions)
-        child_actions = frozenset(child_actions_raw) if not isinstance(child_actions_raw, frozenset) else child_actions_raw
+        child_actions = (
+            frozenset(child_actions_raw) if not isinstance(child_actions_raw, frozenset) else child_actions_raw
+        )
         excess = child_actions - parent.allowed_actions
         if excess:
-            msg = (
-                f"Monotonicity violation: child requests actions {excess} "
-                f"not in parent {parent.capability_id!r}"
-            )
+            msg = f"Monotonicity violation: child requests actions {excess} not in parent {parent.capability_id!r}"
             raise PermissionError(msg)
 
         # Expiry: child cannot outlive parent
@@ -259,9 +256,7 @@ class CapabilityValidator:
         cap.revoked = True
 
         children = [
-            d.child_capability
-            for d in self._derivations.values()
-            if d.parent_capability.capability_id == capability_id
+            d.child_capability for d in self._derivations.values() if d.parent_capability.capability_id == capability_id
         ]
         for child in children:
             self.revoke_capability(child.capability_id)
@@ -336,10 +331,7 @@ class CapabilitySet:
         return tenant in subjects or "*" in subjects
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            action: sorted(subjects)
-            for action, subjects in self._action_subjects.items()
-        }
+        return {action: sorted(subjects) for action, subjects in self._action_subjects.items()}
 
 
 # ── W3-03: Action Permission Check ─────────────────────────────

--- a/engine/boot.py
+++ b/engine/boot.py
@@ -124,9 +124,7 @@ class GraphLifecycle(LifecycleHook):
             logger.info("GDS disabled via settings.gds_enabled=False — skipping scheduler startup")
 
         # W4-04: Start periodic compliance audit flush task
-        self._compliance_flush_task = asyncio.create_task(
-            self._compliance_flush_loop()
-        )
+        self._compliance_flush_task = asyncio.create_task(self._compliance_flush_loop())
         logger.info(
             "W4-04: Compliance flush task started (interval=%ds, buffer_max=%d)",
             settings.compliance_flush_interval,

--- a/engine/causal/attribution.py
+++ b/engine/causal/attribution.py
@@ -69,12 +69,14 @@ class AttributionCalculator:
 
         # Trace backward from outcome to find contributing touchpoints
         cypher = (
-            f"MATCH (outcome:{outcome_label} {{outcome_id: $outcome_id}})\n"
-            f"MATCH path = (touchpoint)-{rel_pattern}->(outcome)\n"
-            f"RETURN touchpoint.entity_id AS touchpoint_id,\n"
-            f"       length(path) AS distance,\n"
-            f"       [r IN relationships(path) | r.confidence] AS confidences\n"
-            f"ORDER BY distance ASC"
+            "MATCH (outcome:"
+            + outcome_label
+            + " {outcome_id: $outcome_id})\n"
+            + f"MATCH path = (touchpoint)-{rel_pattern}->(outcome)\n"
+            + "RETURN touchpoint.entity_id AS touchpoint_id,\n"
+            + "       length(path) AS distance,\n"
+            + "       [r IN relationships(path) | r.confidence] AS confidences\n"
+            + "ORDER BY distance ASC"
         )
 
         results = await self._driver.execute_query(

--- a/engine/causal/causal_compiler.py
+++ b/engine/causal/causal_compiler.py
@@ -59,16 +59,22 @@ class CausalCompiler:
             confidence_clause = f"AND $confidence >= {edge_spec.confidence_threshold}\n"
 
         cypher = (
-            f"MATCH (source:{source_label} {{entity_id: $source_id}})\n"
-            f"MATCH (target:{target_label} {{entity_id: $target_id}})\n"
-            f"{temporal_clause}"
-            f"{confidence_clause}"
-            f"MERGE (source)-[r:{edge_type} {{\n"
-            f"    confidence: $confidence,\n"
-            f"    mechanism: $mechanism,\n"
-            f"    created_at: datetime()\n"
-            f"}}]->(target)\n"
-            f"RETURN r"
+            "MATCH (source:"
+            + source_label
+            + " {entity_id: $source_id})\n"
+            + "MATCH (target:"
+            + target_label
+            + " {entity_id: $target_id})\n"
+            + temporal_clause
+            + confidence_clause
+            + "MERGE (source)-[r:"
+            + edge_type
+            + " {\n"
+            + "    confidence: $confidence,\n"
+            + "    mechanism: $mechanism,\n"
+            + "    created_at: datetime()\n"
+            + "}]->(target)\n"
+            + "RETURN r"
         )
 
         return cypher

--- a/engine/compliance/audit_persistence.py
+++ b/engine/compliance/audit_persistence.py
@@ -4,11 +4,15 @@ to PostgreSQL instead of warning db_pool=None.
 
 Call configure_audit_pool(pool) at app startup after asyncpg.create_pool().
 """
-from __future__ import annotations
-import logging, time
-from typing import Any
 
-import asyncpg  # type: ignore
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import asyncpg  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +69,7 @@ async def flush_audit_entries(entries: list[dict[str, Any]]) -> int:
     ]
     async with _POOL.acquire() as conn:
         await conn.executemany(
-            "INSERT INTO audit_log (tenant_id, actor, action, detail, created_at) "
-            "VALUES ($1, $2, $3, $4, $5)",
+            "INSERT INTO audit_log (tenant_id, actor, action, detail, created_at) VALUES ($1, $2, $3, $4, $5)",
             rows,
         )
     logger.debug("audit_persistence: flushed %d entries to PostgreSQL", len(rows))

--- a/engine/contract_enforcement.py
+++ b/engine/contract_enforcement.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 # Error hierarchy
 # ---------------------------------------------------------------------------
 
+
 class ContractViolationError(RuntimeError):
     """Raised whenever an inter-service packet fails contract validation.
 
@@ -53,9 +54,9 @@ _ALLOWED_PACKET_TYPES: frozenset[str] = frozenset(
         "enrich_result",
         "inference_result",
         "graph_sync",
-        "graph_inference_result",   # Gap-2: new type for return channel
-        "schema_proposal",          # Gap-10: was missing, caused ValidationError
-        "community_export",         # Gap-6: community label export to ENRICH
+        "graph_inference_result",  # Gap-2: new type for return channel
+        "schema_proposal",  # Gap-10: was missing, caused ValidationError
+        "community_export",  # Gap-6: community label export to ENRICH
         "health_check",
         "admin_command",
     ]
@@ -82,6 +83,7 @@ _REQUIRED_FIELDS: dict[str, list[str]] = {
 # ---------------------------------------------------------------------------
 # Core enforcement function
 # ---------------------------------------------------------------------------
+
 
 def enforce_packet_envelope(
     packet: Any,
@@ -157,9 +159,17 @@ def _verify_content_hash(
 ) -> None:
     """Recompute SHA-256 over the canonical content payload and compare."""
     # Content payload = everything except hash fields and metadata
-    _HASH_EXCLUDED = {"content_hash", "envelope_hash", "packet_id", "packet_type",
-                      "type", "created_at", "lineage", "tenant_context"}
-    content_payload = {k: v for k, v in packet.items() if k not in _HASH_EXCLUDED}
+    hash_excluded = {
+        "content_hash",
+        "envelope_hash",
+        "packet_id",
+        "packet_type",
+        "type",
+        "created_at",
+        "lineage",
+        "tenant_context",
+    }
+    content_payload = {k: v for k, v in packet.items() if k not in hash_excluded}
     try:
         payload_bytes = json.dumps(content_payload, sort_keys=True, default=str).encode()
     except (TypeError, ValueError) as exc:
@@ -181,6 +191,7 @@ def _verify_content_hash(
 # GraphSyncClient wrapper — Gap-1 targeted fix
 # ---------------------------------------------------------------------------
 
+
 def build_graph_sync_packet(
     *,
     tenant_id: str,
@@ -194,7 +205,8 @@ def build_graph_sync_packet(
     Previously GraphSyncClient sent a bare dict with no hashes.
     Use this factory everywhere instead.
     """
-    import uuid, time
+    import time
+    import uuid
 
     content_payload: dict[str, Any] = {
         "entity_type": entity_type,
@@ -208,9 +220,7 @@ def build_graph_sync_packet(
 
     packet_id = f"gs_{uuid.uuid4().hex}"
     envelope_meta = {"packet_id": packet_id, "tenant_id": tenant_id, "content_hash": content_hash}
-    envelope_hash = hashlib.sha256(
-        json.dumps(envelope_meta, sort_keys=True).encode()
-    ).hexdigest()
+    envelope_hash = hashlib.sha256(json.dumps(envelope_meta, sort_keys=True).encode()).hexdigest()
 
     packet = {
         "packet_id": packet_id,
@@ -242,7 +252,8 @@ def build_schema_proposal_packet(
     Gap-4 + Gap-10 fix: Build a valid schema_proposal PacketEnvelope.
     Previously SchemaProposal was computed but never emitted.
     """
-    import uuid, time
+    import time
+    import uuid
 
     content_payload: dict[str, Any] = {
         "proposed_fields": proposed_fields,
@@ -252,9 +263,7 @@ def build_schema_proposal_packet(
     content_hash = hashlib.sha256(payload_bytes).hexdigest()
     packet_id = f"sp_{uuid.uuid4().hex}"
     envelope_meta = {"packet_id": packet_id, "tenant_id": tenant_id, "content_hash": content_hash}
-    envelope_hash = hashlib.sha256(
-        json.dumps(envelope_meta, sort_keys=True).encode()
-    ).hexdigest()
+    envelope_hash = hashlib.sha256(json.dumps(envelope_meta, sort_keys=True).encode()).hexdigest()
 
     packet = {
         "packet_id": packet_id,

--- a/engine/convergence_controller_patch.py
+++ b/engine/convergence_controller_patch.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 # Gap-7: Robust per_field_confidence extractor
 # ---------------------------------------------------------------------------
 
+
 def extract_per_field_confidence(feature_vector: dict[str, Any]) -> dict[str, float]:
     """
     Extract per-field confidence scores from a feature vector.
@@ -51,15 +52,18 @@ def extract_per_field_confidence(feature_vector: dict[str, Any]) -> dict[str, fl
             flat_val = float(flat)
         except (TypeError, ValueError):
             flat_val = 0.0
-        _META_KEYS = {"confidence", "overall_confidence", "pass_number",
-                      "entity_id", "tenant_id", "per_field_confidence", "field_scores"}
-        return {
-            k: flat_val
-            for k in feature_vector
-            if k not in _META_KEYS
+        meta_keys = {
+            "confidence",
+            "overall_confidence",
+            "pass_number",
+            "entity_id",
+            "tenant_id",
+            "per_field_confidence",
+            "field_scores",
         }
+        return {k: flat_val for k in feature_vector if k not in meta_keys}
 
-    # Strategy 4: no confidence info — return empty (caller treats all fields as uncertain)
+    # Strategy 4: no confidence info - return empty (caller treats all fields as uncertain)
     logger.debug(
         "extract_per_field_confidence: no confidence data found in feature_vector keys=%s",
         list(feature_vector.keys()),
@@ -71,11 +75,12 @@ def extract_per_field_confidence(feature_vector: dict[str, Any]) -> dict[str, fl
 # Gap-2 integration: inject return-channel targets into entity known_fields
 # ---------------------------------------------------------------------------
 
+
 async def apply_return_channel_targets(
     entity: dict[str, Any],
     tenant_id: str,
     *,
-    timeout: float = 0.05,
+    timeout: float = 0.05,  # noqa: ASYNC109
 ) -> dict[str, Any]:
     """
     Drain the GraphToEnrichReturnChannel for this tenant and inject any
@@ -93,7 +98,7 @@ async def apply_return_channel_targets(
     matched = 0
     for target in targets:
         if target.entity_id == str(entity_id):
-            # Inject as a seed value — only if the field is currently absent or low-confidence
+            # Inject as a seed value - only if the field is currently absent or low-confidence
             existing = entity.get(target.field_name)
             if existing is None:
                 entity[target.field_name] = target.seed_value
@@ -117,6 +122,7 @@ async def apply_return_channel_targets(
 # ---------------------------------------------------------------------------
 # Gap-4: SchemaProposal emission
 # ---------------------------------------------------------------------------
+
 
 async def emit_schema_proposal(
     proposed_fields: list[dict[str, Any]],
@@ -144,6 +150,7 @@ async def emit_schema_proposal(
     # In the current architecture this goes to the chassis event router
     try:
         from chassis.events import emit_event
+
         await emit_event(packet_type="schema_proposal", payload=packet)
         logger.info(
             "Emitted schema_proposal packet for tenant=%s with %d new fields (packet_id=%s)",
@@ -164,6 +171,7 @@ async def emit_schema_proposal(
 # ---------------------------------------------------------------------------
 # Gap-8: domain_spec enforcement wrapper
 # ---------------------------------------------------------------------------
+
 
 class DomainSpecRequiredError(TypeError):
     """Raised when run_convergence_loop is called without domain_spec."""

--- a/engine/diagnostics/__init__.py
+++ b/engine/diagnostics/__init__.py
@@ -11,12 +11,13 @@ status: active
 
 Algorithmic diagnostics for persona composition and drift detection.
 """
-from engine.diagnostics.fingerprint import AlgorithmicFingerprint, compute_fingerprint
+
 from engine.diagnostics.dissimilarity import chi_squared_dissimilarity, detect_drift
+from engine.diagnostics.fingerprint import AlgorithmicFingerprint, compute_fingerprint
 
 __all__ = [
     "AlgorithmicFingerprint",
-    "compute_fingerprint",
     "chi_squared_dissimilarity",
+    "compute_fingerprint",
     "detect_drift",
 ]

--- a/engine/diagnostics/dissimilarity.py
+++ b/engine/diagnostics/dissimilarity.py
@@ -20,6 +20,7 @@ is raised.
 This implements the "Algorithmic Fingerprinting" diagnostic described
 in the CEG Integration Blueprint.
 """
+
 from __future__ import annotations
 
 import logging
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 # ── Chi-Squared Dissimilarity ────────────────────────────────
+
 
 def chi_squared_dissimilarity(
     baseline: dict[str, float],
@@ -79,10 +81,11 @@ def _euclidean_distance(vec_a: list[float], vec_b: list[float]) -> float:
         vec_a = vec_a + [0.0] * (max_len - len(vec_a))
         vec_b = vec_b + [0.0] * (max_len - len(vec_b))
 
-    return sum((a - b) ** 2 for a, b in zip(vec_a, vec_b)) ** 0.5
+    return sum((a - b) ** 2 for a, b in zip(vec_a, vec_b, strict=True)) ** 0.5
 
 
 # ── Drift Detection ─────────────────────────────────────────
+
 
 @dataclass(frozen=True)
 class DriftReport:
@@ -102,6 +105,7 @@ class DriftReport:
         drift_reasons: List of human-readable reasons for drift detection.
         severity: "none" | "low" | "medium" | "high" based on magnitude.
     """
+
     persona_id: str
     baseline_window: str
     current_window: str
@@ -166,16 +170,13 @@ def detect_drift(
     if baseline.persona_id != current.persona_id:
         logger.warning(
             "Comparing fingerprints from different personas: %s vs %s",
-            baseline.persona_id, current.persona_id,
+            baseline.persona_id,
+            current.persona_id,
         )
 
     # Compute metrics
-    score_dissim = chi_squared_dissimilarity(
-        baseline.score_distribution, current.score_distribution
-    )
-    dim_dissim = chi_squared_dissimilarity(
-        baseline.dimension_dominance, current.dimension_dominance
-    )
+    score_dissim = chi_squared_dissimilarity(baseline.score_distribution, current.score_distribution)
+    dim_dissim = chi_squared_dissimilarity(baseline.dimension_dominance, current.dimension_dominance)
 
     vec_a = baseline.to_vector()
     vec_b = current.to_vector()
@@ -188,31 +189,22 @@ def detect_drift(
     reasons: list[str] = []
 
     if score_dissim > score_threshold:
-        reasons.append(
-            f"Score distribution shifted: chi2={score_dissim:.4f} > {score_threshold}"
-        )
+        reasons.append(f"Score distribution shifted: chi2={score_dissim:.4f} > {score_threshold}")
 
     if dim_dissim > dimension_threshold:
-        reasons.append(
-            f"Dimension dominance shifted: chi2={dim_dissim:.4f} > {dimension_threshold}"
-        )
+        reasons.append(f"Dimension dominance shifted: chi2={dim_dissim:.4f} > {dimension_threshold}")
 
     if vec_dist > vector_threshold:
-        reasons.append(
-            f"Full vector distance: {vec_dist:.4f} > {vector_threshold}"
-        )
+        reasons.append(f"Full vector distance: {vec_dist:.4f} > {vector_threshold}")
 
     if abs(entropy_delta) > entropy_threshold:
         direction = "increased" if entropy_delta > 0 else "decreased"
-        reasons.append(
-            f"Entropy {direction}: delta={entropy_delta:.4f}, |delta| > {entropy_threshold}"
-        )
+        reasons.append(f"Entropy {direction}: delta={entropy_delta:.4f}, |delta| > {entropy_threshold}")
 
     if abs(concentration_delta) > concentration_threshold:
         direction = "increased" if concentration_delta > 0 else "decreased"
         reasons.append(
-            f"Concentration {direction}: delta={concentration_delta:.4f}, "
-            f"|delta| > {concentration_threshold}"
+            f"Concentration {direction}: delta={concentration_delta:.4f}, |delta| > {concentration_threshold}"
         )
 
     drift_detected = len(reasons) > 0
@@ -244,12 +236,16 @@ def detect_drift(
     if drift_detected:
         logger.warning(
             "Drift detected for persona=%s severity=%s reasons=%d",
-            current.persona_id, severity, len(reasons),
+            current.persona_id,
+            severity,
+            len(reasons),
         )
     else:
         logger.info(
             "No drift detected for persona=%s (score_chi2=%.4f dim_chi2=%.4f)",
-            current.persona_id, score_dissim, dim_dissim,
+            current.persona_id,
+            score_dissim,
+            dim_dissim,
         )
 
     return report

--- a/engine/diagnostics/fingerprint.py
+++ b/engine/diagnostics/fingerprint.py
@@ -22,6 +22,7 @@ A fingerprint captures *what kinds of results* a persona produces:
 This is the foundation for the dissimilarity module which detects
 when a persona's behavior has changed significantly.
 """
+
 from __future__ import annotations
 
 import logging
@@ -50,6 +51,7 @@ def _bucket_label(score: float, boundaries: tuple[float, ...], labels: tuple[str
 
 # ── Fingerprint Data Structure ───────────────────────────────
 
+
 @dataclass(frozen=True)
 class AlgorithmicFingerprint:
     """
@@ -66,6 +68,7 @@ class AlgorithmicFingerprint:
         top_dimension: The dimension that most frequently dominates.
         concentration_ratio: Fraction of candidates in the single most common bucket.
     """
+
     persona_id: str
     window_id: str
     sample_count: int
@@ -89,6 +92,7 @@ class AlgorithmicFingerprint:
 
 
 # ── Computation ──────────────────────────────────────────────
+
 
 def compute_fingerprint(
     persona_id: str,
@@ -127,7 +131,7 @@ def compute_fingerprint(
             persona_id=persona_id,
             window_id=window_id,
             sample_count=0,
-            score_distribution={label: 0.0 for label in bucket_labels},
+            score_distribution=dict.fromkeys(bucket_labels, 0.0),
             dimension_dominance={},
             entropy=0.0,
             top_dimension="none",
@@ -152,10 +156,7 @@ def compute_fingerprint(
         # Dimension dominance
         dim_scores = candidate.get(dimension_scores_key, {})
         if isinstance(dim_scores, dict) and dim_scores:
-            numeric_dims = {
-                k: v for k, v in dim_scores.items()
-                if isinstance(v, (int, float))
-            }
+            numeric_dims = {k: v for k, v in dim_scores.items() if isinstance(v, (int, float))}
             if numeric_dims:
                 top_dim = max(numeric_dims, key=lambda k: abs(numeric_dims[k]))
                 dimension_wins[top_dim] += 1
@@ -164,10 +165,7 @@ def compute_fingerprint(
     score_distribution = {label: bucket_counts.get(label, 0) / n for label in bucket_labels}
 
     total_dim_wins = sum(dimension_wins.values()) or 1
-    dimension_dominance = {
-        dim: count / total_dim_wins
-        for dim, count in dimension_wins.most_common()
-    }
+    dimension_dominance = {dim: count / total_dim_wins for dim, count in dimension_wins.most_common()}
 
     # Shannon entropy of score distribution
     entropy = 0.0
@@ -192,7 +190,11 @@ def compute_fingerprint(
 
     logger.info(
         "Computed fingerprint: persona=%s window=%s n=%d entropy=%.4f top_dim=%s",
-        persona_id, window_id, n, entropy, top_dimension,
+        persona_id,
+        window_id,
+        n,
+        entropy,
+        top_dimension,
     )
 
     return fingerprint

--- a/engine/gds/scheduler.py
+++ b/engine/gds/scheduler.py
@@ -215,8 +215,7 @@ class GDSScheduler:
 
         if cycle_members:
             logger.error(
-                "Circular dependency detected among GDS jobs: %s. "
-                "Placing in fallback wave.",
+                "Circular dependency detected among GDS jobs: %s. Placing in fallback wave.",
                 sorted(cycle_members),
             )
             waves.append([job_map[alg] for alg in sorted(cycle_members)])
@@ -244,10 +243,7 @@ class GDSScheduler:
         S2-15: Supports stability_runs for non-deterministic algorithms.
         """
         resolved_agg = self.resolve_aggregation_strategy(job_spec)
-        logger.info(
-            f"Starting GDS job {job_spec.name} — algorithm={job_spec.algorithm}, "
-            f"aggregation={resolved_agg}"
-        )
+        logger.info(f"Starting GDS job {job_spec.name} — algorithm={job_spec.algorithm}, aggregation={resolved_agg}")
         start = datetime.now()
         result = {}
 
@@ -710,26 +706,25 @@ class GDSScheduler:
                 result = await self._run_louvain(job_spec)
                 all_results.append(result)
             except Exception as e:
-                logger.warning(f"Stability run {i+1}/{runs} failed: {e}")
+                logger.warning(f"Stability run {i + 1}/{runs} failed: {e}")
 
         if not all_results:
             return {"status": "failed", "error": "All stability runs failed"}
 
         # Aggregate: average community count and modularity
-        avg_communities = sum(
-            r.get("communities", 0) or 0 for r in all_results
-        ) / len(all_results)
-        avg_modularity = sum(
-            r.get("modularity", 0.0) or 0.0 for r in all_results
-        ) / len(all_results)
+        avg_communities = sum(r.get("communities", 0) or 0 for r in all_results) / len(all_results)
+        avg_modularity = sum(r.get("modularity", 0.0) or 0.0 for r in all_results) / len(all_results)
 
         return {
             "communities": round(avg_communities),
             "modularity": round(avg_modularity, 6),
             "stability_runs": len(all_results),
             "stability_coefficient": round(
-                1.0 - (max(r.get("modularity", 0.0) or 0.0 for r in all_results)
-                       - min(r.get("modularity", 0.0) or 0.0 for r in all_results)),
+                1.0
+                - (
+                    max(r.get("modularity", 0.0) or 0.0 for r in all_results)
+                    - min(r.get("modularity", 0.0) or 0.0 for r in all_results)
+                ),
                 6,
             ),
         }

--- a/engine/graph/circuit_breaker.py
+++ b/engine/graph/circuit_breaker.py
@@ -27,8 +27,9 @@ import asyncio
 import enum
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, TypeVar
+from typing import Any, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +58,7 @@ class CircuitOpenError(Exception):
     def __init__(self, breaker_name: str, retry_after: float) -> None:
         self.breaker_name = breaker_name
         self.retry_after = retry_after
-        super().__init__(
-            f"Circuit breaker '{breaker_name}' is OPEN. Retry after {retry_after:.1f}s."
-        )
+        super().__init__(f"Circuit breaker '{breaker_name}' is OPEN. Retry after {retry_after:.1f}s.")
 
 
 # ---------------------------------------------------------------------------

--- a/engine/graph/community_export.py
+++ b/engine/graph/community_export.py
@@ -4,7 +4,9 @@ as known_fields context so convergence_controller uses them in Pass N+1.
 
 Attach to GDSScheduler post-job completion hook for "louvain" jobs.
 """
+
 from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -38,9 +40,7 @@ async def export_community_labels_to_enrich(
             database=domain_id,
         )
     except Exception:
-        logger.exception(
-            "community_export: failed to query community labels tenant=%s", tenant_id
-        )
+        logger.exception("community_export: failed to query community labels tenant=%s", tenant_id)
         return {"status": "error", "exported": 0}
 
     if not records:
@@ -52,7 +52,7 @@ async def export_community_labels_to_enrich(
             "entity_id": r["entity_id"],
             "field": "community_id",
             "value": r["community_id"],
-            "confidence": 0.95,   # Louvain is deterministic
+            "confidence": 0.95,  # Louvain is deterministic
             "rule": "louvain_community_detection",
         }
         for r in records
@@ -70,6 +70,7 @@ async def export_community_labels_to_enrich(
     count = await channel.submit(envelope)
     logger.info(
         "community_export: submitted %d community label targets tenant=%s",
-        count, tenant_id,
+        count,
+        tenant_id,
     )
     return {"status": "ok", "exported": count, "packet_id": envelope.packet_id}

--- a/engine/graph/driver.py
+++ b/engine/graph/driver.py
@@ -122,6 +122,4 @@ class GraphDriver:
 
         Raises CircuitOpenError (maps to 503) if breaker is OPEN.
         """
-        return await self._circuit_breaker.call(
-            self._raw_execute_query, cypher, parameters, database
-        )
+        return await self._circuit_breaker.call(self._raw_execute_query, cypher, parameters, database)

--- a/engine/graph/graph_sync_client_fix.py
+++ b/engine/graph/graph_sync_client_fix.py
@@ -6,14 +6,16 @@ PacketLineage, and TenantContext.
 Usage: Drop this over GraphSyncClient in graph/sync/client.py and update
 the import at the call site.
 """
+
 from __future__ import annotations
+
 import logging
 from typing import Any
 
 from engine.contract_enforcement import (
+    ContractViolationError,
     build_graph_sync_packet,
     enforce_packet_envelope,
-    ContractViolationError,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,7 +73,7 @@ class GraphSyncClient:
         envelope = self._build_envelope(entity_type, batch, correlation_id)
 
         try:
-            result = await self._driver.execute_write(
+            await self._driver.execute_write(
                 _write_batch_tx,
                 entity_type=entity_type,
                 batch=envelope["content"]["batch"],
@@ -80,16 +82,17 @@ class GraphSyncClient:
             )
             logger.info(
                 "GraphSyncClient: synced %d %s entities tenant=%s packet_id=%s",
-                len(batch), entity_type, self._tenant_id, envelope["packet_id"],
+                len(batch),
+                entity_type,
+                self._tenant_id,
+                envelope["packet_id"],
             )
             return {"status": "ok", "synced": len(batch), "packet_id": envelope["packet_id"]}
 
         except ContractViolationError:
             raise
-        except Exception as exc:
-            logger.exception(
-                "GraphSyncClient: write failed for packet_id=%s", envelope.get("packet_id")
-            )
+        except Exception:
+            logger.exception("GraphSyncClient: write failed for packet_id=%s", envelope.get("packet_id"))
             raise
 
 

--- a/engine/graph_return_channel.py
+++ b/engine/graph_return_channel.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Domain model
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class EnrichmentTarget:
     """A re-enrichment directive produced by a GRAPH inference output."""
@@ -131,6 +132,7 @@ class GraphInferenceResultEnvelope:
 # Return channel — singleton per process
 # ---------------------------------------------------------------------------
 
+
 class GraphToEnrichReturnChannel:
     """
     Async queue that bridges GRAPH inference outputs back to ENRICH.
@@ -143,7 +145,7 @@ class GraphToEnrichReturnChannel:
         targets = await channel.drain(tenant_id="acme", timeout=0.5)
     """
 
-    _instance: "GraphToEnrichReturnChannel | None" = None
+    _instance: GraphToEnrichReturnChannel | None = None
 
     def __init__(self, maxsize: int = 10_000) -> None:
         # Per-tenant queues: tenant_id → asyncio.Queue[EnrichmentTarget]
@@ -154,7 +156,7 @@ class GraphToEnrichReturnChannel:
         self._rejected: int = 0
 
     @classmethod
-    def get_instance(cls) -> "GraphToEnrichReturnChannel":
+    def get_instance(cls) -> GraphToEnrichReturnChannel:
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
@@ -204,7 +206,7 @@ class GraphToEnrichReturnChannel:
         self,
         tenant_id: str,
         *,
-        timeout: float = 0.1,
+        timeout: float = 0.1,  # noqa: ASYNC109
         max_targets: int = 500,
     ) -> list[EnrichmentTarget]:
         """
@@ -223,7 +225,7 @@ class GraphToEnrichReturnChannel:
                 target = await asyncio.wait_for(q.get(), timeout=remaining)
                 targets.append(target)
                 q.task_done()
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 break
         self._drained += len(targets)
         if targets:
@@ -247,6 +249,7 @@ class GraphToEnrichReturnChannel:
 # Integration helper: build a valid envelope from raw GRAPH output
 # ---------------------------------------------------------------------------
 
+
 def build_graph_inference_result_envelope(
     *,
     tenant_id: str,
@@ -264,9 +267,7 @@ def build_graph_inference_result_envelope(
         "tenant_id": tenant_id,
         "content_hash": content_hash,
     }
-    envelope_hash = hashlib.sha256(
-        json.dumps(envelope_payload, sort_keys=True).encode()
-    ).hexdigest()
+    envelope_hash = hashlib.sha256(json.dumps(envelope_payload, sort_keys=True).encode()).hexdigest()
     return GraphInferenceResultEnvelope(
         packet_id=packet_id,
         tenant_id=tenant_id,

--- a/engine/handlers.py
+++ b/engine/handlers.py
@@ -514,10 +514,7 @@ async def handle_match(tenant: str, payload: dict[str, Any]) -> dict[str, Any]:
                 results = apply_constraint_penalties(list(results), constraint_dicts)
 
             # Spec-driven Pareto filter using declared objectives
-            arb_dims = [
-                obj.dimension
-                for obj in domain_spec.decision_arbitration.pareto_config.objectives
-            ]
+            arb_dims = [obj.dimension for obj in domain_spec.decision_arbitration.pareto_config.objectives]
             if arb_dims and len(results) > 1:
                 arb_pareto = apply_pareto_filter(results, arb_dims)
                 if pareto_metadata is None:
@@ -1317,10 +1314,7 @@ async def handle_admin(tenant: str, payload: dict[str, Any]) -> dict[str, Any]:
                 tenant=tenant,
             )
 
-        dimension_names = [
-            obj.dimension
-            for obj in spec.decision_arbitration.pareto_config.objectives
-        ]
+        dimension_names = [obj.dimension for obj in spec.decision_arbitration.pareto_config.objectives]
 
         if not dimension_names:
             raise ValidationError(
@@ -1365,10 +1359,12 @@ async def handle_admin(tenant: str, payload: dict[str, Any]) -> dict[str, Any]:
                     continue
             if not isinstance(ds, dict):
                 continue
-            outcome_history.append({
-                "dimension_scores": {k: float(v) for k, v in ds.items()},
-                "was_selected": bool(rec.get("was_selected", False)),
-            })
+            outcome_history.append(
+                {
+                    "dimension_scores": {k: float(v) for k, v in ds.items()},
+                    "was_selected": bool(rec.get("was_selected", False)),
+                }
+            )
 
         if len(outcome_history) < 10:
             return {

--- a/engine/hoprag/config.py
+++ b/engine/hoprag/config.py
@@ -37,7 +37,7 @@ experimental findings (n_hop=4, top_k=12, alpha=0.5).
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
@@ -191,9 +191,6 @@ class HopRAGConfig:
             The effective ReasoningMode.
         """
         if self.reasoning_mode == ReasoningMode.LLM and self.traversal_model == TraversalModel.NONE:
-            logger.warning(
-                "reasoning_mode='llm' but traversal_model='none', "
-                "falling back to 'similarity'"
-            )
+            logger.warning("reasoning_mode='llm' but traversal_model='none', falling back to 'similarity'")
             return ReasoningMode.SIMILARITY
         return ReasoningMode(self.reasoning_mode)

--- a/engine/hoprag/indexer.py
+++ b/engine/hoprag/indexer.py
@@ -135,7 +135,7 @@ class GraphIndexBuilder:
             graph_store=neo4j_store,
         )
         result = await builder.build(passage_label="Passage")
-        print(f"Created {result.edges_created} edges")
+        edges_created = result.edges_created
     """
 
     def __init__(
@@ -234,11 +234,7 @@ class GraphIndexBuilder:
                             vertex_id=pq.passage_id,
                             question=triplet.question,
                             keywords=triplet.keywords,
-                            embedding=(
-                                __import__("numpy").array(triplet.embedding)
-                                if triplet.embedding
-                                else None
-                            ),
+                            embedding=(__import__("numpy").array(triplet.embedding) if triplet.embedding else None),
                         )
                     )
                 for triplet in pq.incoming:
@@ -247,11 +243,7 @@ class GraphIndexBuilder:
                             vertex_id=pq.passage_id,
                             question=triplet.question,
                             keywords=triplet.keywords,
-                            embedding=(
-                                __import__("numpy").array(triplet.embedding)
-                                if triplet.embedding
-                                else None
-                            ),
+                            embedding=(__import__("numpy").array(triplet.embedding) if triplet.embedding else None),
                         )
                     )
 

--- a/engine/inference_bridge.py
+++ b/engine/inference_bridge.py
@@ -7,6 +7,7 @@ forcing all callers to migrate to inference_bridge_v2.py (DAG engine).
 This eliminates silent bypass of the DerivationGraph topological sort
 and unlock-value targeting that the v1 bridge was causing.
 """
+
 raise ImportError(
     "engine.inference_bridge (v1) is DISABLED.\n\n"
     "It bypasses the DerivationGraph DAG engine, causing inference to fire "

--- a/engine/inference_rule_registry.py
+++ b/engine/inference_rule_registry.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -27,23 +28,26 @@ logger = logging.getLogger(__name__)
 # Types
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class InferenceContext:
     """Runtime context passed to every inference function."""
+
     tenant_id: str
     domain_id: str
     pass_number: int
     known_fields: dict[str, Any] = field(default_factory=dict)
-    domain_kb: dict[str, Any] = field(default_factory=dict)   # from domain spec KB injection
+    domain_kb: dict[str, Any] = field(default_factory=dict)  # from domain spec KB injection
     confidence_floor: float = 0.55
 
 
 @dataclass
 class InferenceResult:
     """Output of a single inference function execution."""
+
     field_name: str
     value: Any
-    confidence: float          # 0.0–1.0
+    confidence: float  # 0.0-1.0
     rule_name: str
     provenance: str = "inference"
     rationale: str = ""
@@ -62,7 +66,7 @@ class InferenceResult:
 InferenceFn = Callable[[dict[str, Any], InferenceContext], InferenceResult | None]
 
 # ---------------------------------------------------------------------------
-# Registry — populated by @register_inference_rule decorators below
+# Registry - populated by @register_inference_rule decorators below
 # ---------------------------------------------------------------------------
 
 _RULE_REGISTRY: dict[str, InferenceFn] = {}
@@ -70,12 +74,14 @@ _RULE_REGISTRY: dict[str, InferenceFn] = {}
 
 def register_inference_rule(name: str) -> Callable[[InferenceFn], InferenceFn]:
     """Decorator that registers an inference function under `name`."""
+
     def decorator(fn: InferenceFn) -> InferenceFn:
         if name in _RULE_REGISTRY:
             raise ValueError(f"Inference rule '{name}' is already registered")
         _RULE_REGISTRY[name] = fn
         logger.debug("Registered inference rule: %s → %s", name, fn.__qualname__)
         return fn
+
     return decorator
 
 
@@ -83,10 +89,7 @@ def get_rule(name: str) -> InferenceFn:
     """Return a registered rule or raise KeyError with a clear message."""
     if name not in _RULE_REGISTRY:
         available = sorted(_RULE_REGISTRY.keys())
-        raise KeyError(
-            f"Inference rule '{name}' not found in registry. "
-            f"Available rules: {available}"
-        )
+        raise KeyError(f"Inference rule '{name}' not found in registry. Available rules: {available}")
     return _RULE_REGISTRY[name]
 
 
@@ -122,6 +125,7 @@ def execute_rule(
 # Register all domain-agnostic rules here. Domain-specific rules are
 # loaded from domain KB via load_domain_rules() below.
 # ===========================================================================
+
 
 @register_inference_rule("infer_company_size_tier")
 def infer_company_size_tier(entity: dict, ctx: InferenceContext) -> InferenceResult | None:
@@ -198,7 +202,6 @@ def infer_email_domain_from_website(entity: dict, ctx: InferenceContext) -> Infe
 def infer_geography_from_postal_code(entity: dict, ctx: InferenceContext) -> InferenceResult | None:
     """Infer region/country from postal code prefix."""
     postal = entity.get("postal_code") or entity.get("zip_code")
-    country = entity.get("country")
     if not postal:
         return None
     postal_str = str(postal).strip().upper()
@@ -276,12 +279,15 @@ def infer_material_grade_from_mfi(entity: dict, ctx: InferenceContext) -> Infere
     kb = ctx.domain_kb.get("mfi_grade_map", {})
     # Default HDPE thresholds — can be overridden by KB
     if material in ("HDPE", "PE"):
-        grade_map = kb.get("HDPE", [
-            (0.5,  "HD_pipe",       0.88),
-            (2.0,  "HD_blow",       0.85),
-            (8.0,  "HD_injection",  0.83),
-            (float("inf"), "HD_fiber", 0.80),
-        ])
+        grade_map = kb.get(
+            "HDPE",
+            [
+                (0.5, "HD_pipe", 0.88),
+                (2.0, "HD_blow", 0.85),
+                (8.0, "HD_injection", 0.83),
+                (float("inf"), "HD_fiber", 0.80),
+            ],
+        )
     else:
         grade_map = kb.get(material, [(float("inf"), "generic", 0.60)])
     for threshold, grade, conf in grade_map:
@@ -306,10 +312,13 @@ def infer_contamination_tolerance(entity: dict, ctx: InferenceContext) -> Infere
     grade = entity.get("material_grade")
     if not tier or not grade:
         return None
-    _HIGH_TOLERANCE_TIERS = {"micro", "small"}
-    _LOW_GRADE_PATTERNS = {"fiber", "generic"}
-    tolerance = "high" if (tier in _HIGH_TOLERANCE_TIERS or
-                           any(p in str(grade).lower() for p in _LOW_GRADE_PATTERNS)) else "low"
+    high_tolerance_tiers = {"micro", "small"}
+    low_grade_patterns = {"fiber", "generic"}
+    tolerance = (
+        "high"
+        if (tier in high_tolerance_tiers or any(p in str(grade).lower() for p in low_grade_patterns))
+        else "low"
+    )
     conf = 0.78 if tolerance == "high" else 0.72
     return InferenceResult(
         field_name="contamination_tolerance",
@@ -324,7 +333,7 @@ def infer_contamination_tolerance(entity: dict, ctx: InferenceContext) -> Infere
 def infer_icp_fit_score(entity: dict, ctx: InferenceContext) -> InferenceResult | None:
     """
     Generic ICP fit scoring: weighted sum of known firmographic signals.
-    Returns a 0.0–1.0 score in the 'icp_fit_score' field.
+    Returns a 0.0-1.0 score in the 'icp_fit_score' field.
     """
     score = 0.0
     factors = 0
@@ -368,28 +377,39 @@ def infer_buyer_persona(entity: dict, ctx: InferenceContext) -> InferenceResult 
     title_lower = str(title).lower()
     if not title_lower:
         return None
-    _EXEC_KEYWORDS = {"ceo", "coo", "president", "owner", "founder", "vp", "svp", "evp"}
-    _OPS_KEYWORDS = {"operations", "ops", "plant", "facility", "production", "supply"}
-    _PROC_KEYWORDS = {"procurement", "purchasing", "buyer", "sourcing"}
-    _TECH_KEYWORDS = {"engineer", "technical", "r&d", "research", "quality"}
-    for kw in _EXEC_KEYWORDS:
+    exec_keywords = {"ceo", "coo", "president", "owner", "founder", "vp", "svp", "evp"}
+    ops_keywords = {"operations", "ops", "plant", "facility", "production", "supply"}
+    proc_keywords = {"procurement", "purchasing", "buyer", "sourcing"}
+    tech_keywords = {"engineer", "technical", "r&d", "research", "quality"}
+    for kw in exec_keywords:
         if kw in title_lower:
-            return InferenceResult("buyer_persona", "executive", 0.85, "infer_buyer_persona", rationale=f"title={title}")
-    for kw in _PROC_KEYWORDS:
+            return InferenceResult(
+                "buyer_persona", "executive", 0.85, "infer_buyer_persona", rationale=f"title={title}"
+            )
+    for kw in proc_keywords:
         if kw in title_lower:
-            return InferenceResult("buyer_persona", "procurement", 0.83, "infer_buyer_persona", rationale=f"title={title}")
-    for kw in _OPS_KEYWORDS:
+            return InferenceResult(
+                "buyer_persona", "procurement", 0.83, "infer_buyer_persona", rationale=f"title={title}"
+            )
+    for kw in ops_keywords:
         if kw in title_lower:
-            return InferenceResult("buyer_persona", "operations", 0.80, "infer_buyer_persona", rationale=f"title={title}")
-    for kw in _TECH_KEYWORDS:
+            return InferenceResult(
+                "buyer_persona", "operations", 0.80, "infer_buyer_persona", rationale=f"title={title}"
+            )
+    for kw in tech_keywords:
         if kw in title_lower:
-            return InferenceResult("buyer_persona", "technical", 0.78, "infer_buyer_persona", rationale=f"title={title}")
-    return InferenceResult("buyer_persona", "unknown", 0.55, "infer_buyer_persona", rationale=f"title={title} — no match")
+            return InferenceResult(
+                "buyer_persona", "technical", 0.78, "infer_buyer_persona", rationale=f"title={title}"
+            )
+    return InferenceResult(
+        "buyer_persona", "unknown", 0.55, "infer_buyer_persona", rationale=f"title={title} — no match"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Dynamic domain rule loader (Gap-3: KB injection pathway)
 # ---------------------------------------------------------------------------
+
 
 def load_domain_rules(domain_kb: dict[str, Any]) -> int:
     """
@@ -461,7 +481,7 @@ def _register_condition_rule(rule_name: str, spec: dict[str, Any]) -> None:
             confidence=confidence,
             rule_name=rule_name,
             provenance="domain_kb",
-            rationale=f"condition rule from KB",
+            rationale="condition rule from KB",
         )
 
     _RULE_REGISTRY[rule_name] = _rule

--- a/engine/kge/cross_dimensional_ensemble.py
+++ b/engine/kge/cross_dimensional_ensemble.py
@@ -108,10 +108,7 @@ class CrossDimensionalEnsemble:
             ValueError: If propagation_depth is outside [1, 5].
         """
         if not 1 <= propagation_depth <= 5:
-            msg = (
-                f"propagation_depth must be 1-5 (got {propagation_depth}). "
-                f"HGKR paper shows L>3 causes overfitting."
-            )
+            msg = f"propagation_depth must be 1-5 (got {propagation_depth}). HGKR paper shows L>3 causes overfitting."
             raise ValueError(msg)
         self._depth = propagation_depth
 
@@ -150,9 +147,7 @@ class CrossDimensionalEnsemble:
         # Pass 2+: Iterative context-aware refinement
         current_score = pass_1_score
         for _iteration in range(1, self._depth):
-            attention_weights = self._compute_context_attention(
-                dimensional_scores, query_context, current_score
-            )
+            attention_weights = self._compute_context_attention(dimensional_scores, query_context, current_score)
             current_score = self._attention_fusion(dimensional_scores, attention_weights)
             # Update contributions with attention-reweighted values
             for ds in dimensional_scores:
@@ -235,9 +230,7 @@ class CrossDimensionalEnsemble:
 
         Replaces static configured weights with context-aware attention.
         """
-        weighted_sum = sum(
-            ds.score * attention_weights.get(ds.dimension_name, ds.weight) for ds in scores
-        )
+        weighted_sum = sum(ds.score * attention_weights.get(ds.dimension_name, ds.weight) for ds in scores)
         total_weight = sum(attention_weights.values())
         return weighted_sum / total_weight if total_weight > 0 else 0.0
 

--- a/engine/models/outcomes.py
+++ b/engine/models/outcomes.py
@@ -10,12 +10,12 @@ status: active
 --- /L9_META ---
 
 engine/models/outcomes.py
-Milestone 2.2 — Outcome models for Pareto weight discovery
+Milestone 2.2 - Outcome models for Pareto weight discovery
 
 Provides:
 
-1. ``OutcomeRecord`` — Pydantic model for a single match outcome
-2. ``OutcomeHistoryStore`` — In-memory store for outcome history with
+1. ``OutcomeRecord`` - Pydantic model for a single match outcome
+2. ``OutcomeHistoryStore`` - In-memory store for outcome history with
    tenant isolation, TTL-based expiry, and serialization to the format
    expected by ``discover_pareto_weights()``.
 
@@ -23,12 +23,13 @@ The in-memory store is suitable for single-instance deployments.  For
 multi-instance production, replace with a PostgreSQL-backed implementation
 that reads from the ``transaction_outcomes`` table.
 """
+
 from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
-from typing import Any, Optional
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -43,19 +44,15 @@ class OutcomeRecord(BaseModel):
 
     match_id: str = Field(description="ID of the match request that produced this outcome")
     candidate_id: str = Field(description="ID of the candidate entity")
-    dimension_scores: dict[str, float] = Field(
-        description="Per-dimension scores at the time of the match"
-    )
-    was_selected: bool = Field(
-        description="Whether the customer/user selected this candidate"
-    )
-    feedback_score: Optional[float] = Field(
+    dimension_scores: dict[str, float] = Field(description="Per-dimension scores at the time of the match")
+    was_selected: bool = Field(description="Whether the customer/user selected this candidate")
+    feedback_score: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
         description="Optional explicit feedback score (0.0-1.0)",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
 # ── Store ────────────────────────────────────────────────────────────────────
@@ -103,7 +100,7 @@ class OutcomeHistoryStore:
             Each dict has ``dimension_scores`` (dict[str, float]) and
             ``was_selected`` (bool).
         """
-        cutoff = datetime.utcnow() - timedelta(days=days)
+        cutoff = datetime.now(UTC) - timedelta(days=days)
         bucket = self._history.get(tenant, [])
 
         recent = [

--- a/engine/outcomes/schema.py
+++ b/engine/outcomes/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -13,7 +13,7 @@ class OutcomeEvent(BaseModel):
     action_name: str
     canonical_label: str
     outcome_state: str
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
 class ReinforcementResult(BaseModel):

--- a/engine/packet/bridge.py
+++ b/engine/packet/bridge.py
@@ -6,7 +6,9 @@ from l9_core.models import PacketEnvelope, make_root_packet
 
 
 class PacketBridge:
-    def inflate_ingress(self, *, tenant_id: str, actor: str, packet_type: str, payload: dict[str, Any]) -> PacketEnvelope:
+    def inflate_ingress(
+        self, *, tenant_id: str, actor: str, packet_type: str, payload: dict[str, Any]
+    ) -> PacketEnvelope:
         return make_root_packet(packet_type=packet_type, tenant_id=tenant_id, actor=actor, payload=payload)
 
     def attach_entity_semantics(

--- a/engine/packet/packet_store.py
+++ b/engine/packet/packet_store.py
@@ -21,6 +21,7 @@ Configuration via environment variables:
   - PACKET_STORE_POOL_MIN: Minimum pool connections (default: 2)
   - PACKET_STORE_POOL_MAX: Maximum pool connections (default: 10)
 """
+
 from __future__ import annotations
 
 import json
@@ -86,6 +87,7 @@ _INSERT_DELEGATION_SQL = """
 
 # ── Pool Management ──────────────────────────────────────────
 
+
 class _PoolManager:
     """Lazy-initialised asyncpg connection pool."""
 
@@ -98,18 +100,16 @@ class _PoolManager:
             return self._pool
 
         try:
-            import asyncpg  # noqa: F811
+            import asyncpg
         except ImportError as exc:
             raise RuntimeError(
-                "asyncpg is required for PacketStore persistence. "
-                "Install with: pip install asyncpg"
+                "asyncpg is required for PacketStore persistence. Install with: pip install asyncpg"
             ) from exc
 
         dsn = os.environ.get("PACKET_STORE_DSN")
         if not dsn:
             raise RuntimeError(
-                "PACKET_STORE_DSN environment variable is required. "
-                "Set it to your PostgreSQL connection string."
+                "PACKET_STORE_DSN environment variable is required. Set it to your PostgreSQL connection string."
             )
 
         min_size = int(os.environ.get("PACKET_STORE_POOL_MIN", "2"))
@@ -123,7 +123,8 @@ class _PoolManager:
         )
         logger.info(
             "PacketStore pool initialized: min=%d max=%d",
-            min_size, max_size,
+            min_size,
+            max_size,
         )
         return self._pool
 
@@ -139,6 +140,7 @@ _pool_manager = _PoolManager()
 
 
 # ── Extraction Helpers ───────────────────────────────────────
+
 
 def _extract_packet_row(packet: PacketEnvelope) -> tuple[Any, ...]:
     """Extract a flat tuple of values from a PacketEnvelope for INSERT."""
@@ -193,6 +195,7 @@ def _extract_packet_row(packet: PacketEnvelope) -> tuple[Any, ...]:
 
 # ── PacketStore ──────────────────────────────────────────────
 
+
 class PacketStore:
     """Async persistence layer for PacketEnvelope request/response pairs.
 
@@ -214,59 +217,57 @@ class PacketStore:
         """
         if not _PACKET_STORE_ENABLED:
             logger.debug(
-                "PacketStore is disabled. Set PACKET_STORE_ENABLED=true to enable. "
-                "packet_id=%s",
+                "PacketStore is disabled. Set PACKET_STORE_ENABLED=true to enable. packet_id=%s",
                 request.packet_id,
             )
             return
 
         pool = await _pool_manager.get_pool()
 
-        async with pool.acquire() as conn:
-            async with conn.transaction():
-                # Insert both packets
-                for packet in (request, response):
-                    row = _extract_packet_row(packet)
-                    await conn.execute(_INSERT_PACKET_SQL, *row)
+        async with pool.acquire() as conn, conn.transaction():
+            # Insert both packets
+            for packet in (request, response):
+                row = _extract_packet_row(packet)
+                await conn.execute(_INSERT_PACKET_SQL, *row)
 
-                    # Insert hop trace entries
-                    for seq, hop in enumerate(packet.hop_trace):
-                        await conn.execute(
-                            _INSERT_HOP_SQL,
-                            str(packet.packet_id),
-                            hop.node_id,
-                            hop.action,
-                            hop.entered_at,
-                            hop.exited_at,
-                            hop.status,
-                            hop.signature,
-                            seq,
-                        )
+                # Insert hop trace entries
+                for seq, hop in enumerate(packet.hop_trace):
+                    await conn.execute(
+                        _INSERT_HOP_SQL,
+                        str(packet.packet_id),
+                        hop.node_id,
+                        hop.action,
+                        hop.entered_at,
+                        hop.exited_at,
+                        hop.status,
+                        hop.signature,
+                        seq,
+                    )
 
-                    # Insert delegation chain entries
-                    for seq, deleg in enumerate(packet.delegation_chain):
-                        await conn.execute(
-                            _INSERT_DELEGATION_SQL,
-                            str(packet.packet_id),
-                            deleg.delegator,
-                            deleg.delegatee,
-                            list(deleg.scope),
-                            deleg.granted_at,
-                            deleg.expires_at,
-                            deleg.proof_hash,
-                            seq,
-                        )
+                # Insert delegation chain entries
+                for seq, deleg in enumerate(packet.delegation_chain):
+                    await conn.execute(
+                        _INSERT_DELEGATION_SQL,
+                        str(packet.packet_id),
+                        deleg.delegator,
+                        deleg.delegatee,
+                        list(deleg.scope),
+                        deleg.granted_at,
+                        deleg.expires_at,
+                        deleg.proof_hash,
+                        seq,
+                    )
 
-                    # Insert lineage graph edges
-                    for parent_id in packet.lineage.parent_ids:
-                        await conn.execute(
-                            _INSERT_LINEAGE_SQL,
-                            str(parent_id),
-                            str(packet.packet_id),
-                            packet.lineage.generation,
-                            packet.lineage.derivation_type,
-                            datetime.now(UTC),
-                        )
+                # Insert lineage graph edges
+                for parent_id in packet.lineage.parent_ids:
+                    await conn.execute(
+                        _INSERT_LINEAGE_SQL,
+                        str(parent_id),
+                        str(packet.packet_id),
+                        packet.lineage.generation,
+                        packet.lineage.derivation_type,
+                        datetime.now(UTC),
+                    )
 
         logger.info(
             "PacketStore persisted pair: request=%s response=%s",

--- a/engine/personas/composer.py
+++ b/engine/personas/composer.py
@@ -169,9 +169,7 @@ def create_composite_persona(
         raise ValueError(msg)
 
     # Use scores as weights for blending
-    blend_input: list[WeightedPersona] = [
-        {"persona": p["persona"], "weight": p["score"]} for p in selected
-    ]
+    blend_input: list[WeightedPersona] = [{"persona": p["persona"], "weight": p["score"]} for p in selected]
     blended_vector = blend_personas(blend_input)
 
     # Build hybrid system prompt from relevant parts

--- a/engine/personas/suppression.py
+++ b/engine/personas/suppression.py
@@ -52,11 +52,7 @@ def build_constraint_block(persona: Persona) -> str:
 
     constraints = [_CONSTRAINT_TEMPLATE.format(behavior=b) for b in persona.forbidden_behaviors]
 
-    block = (
-        f"\n\n{_CONSTRAINT_BLOCK_START}\n"
-        + "\n".join(constraints)
-        + f"\n{_CONSTRAINT_BLOCK_END}\n"
-    )
+    block = f"\n\n{_CONSTRAINT_BLOCK_START}\n" + "\n".join(constraints) + f"\n{_CONSTRAINT_BLOCK_END}\n"
 
     logger.debug(
         "Built %d constraint(s) for persona '%s'",

--- a/engine/personas/synthesis.py
+++ b/engine/personas/synthesis.py
@@ -140,15 +140,11 @@ def build_synthesis_prompt(
     contributions: list[str] = []
     for entry in weighted:
         pct = round(entry["weight"] * 100, 1)
-        contributions.append(
-            f"--- [{entry['output'].persona_name}] (relevance: {pct}%) ---\n{entry['output'].content}"
-        )
+        contributions.append(f"--- [{entry['output'].persona_name}] (relevance: {pct}%) ---\n{entry['output'].content}")
 
     prompt = (
         "You are synthesizing multiple cognitive perspectives into a single coherent response.\n\n"
-        "Weight contributions based on relevance scores:\n"
-        + "\n".join(weight_lines)
-        + "\n\n"
+        "Weight contributions based on relevance scores:\n" + "\n".join(weight_lines) + "\n\n"
         "Prioritize insights from higher-relevance perspectives. "
         "Remove persona identity traces from the final output.\n\n"
     )

--- a/engine/scoring/assembler.py
+++ b/engine/scoring/assembler.py
@@ -445,7 +445,9 @@ class ScoringAssembler:
         Ref: Liu et al., Scientific Reports (2023) 13:6987, §3.2 preference attention.
         """
         default = float(dim.defaultwhennull)  # nosemgrep: float-requires-try-except
-        sample_k = self.scoring_spec.preference_sample_size if hasattr(self.scoring_spec, "preference_sample_size") else 28
+        sample_k = (
+            self.scoring_spec.preference_sample_size if hasattr(self.scoring_spec, "preference_sample_size") else 28
+        )
 
         # Configurable properties with safe defaults
         metadata = dim.metadata if hasattr(dim, "metadata") and dim.metadata else {}
@@ -492,10 +494,7 @@ class ScoringAssembler:
         community_props = metadata.get("community_properties", [])
         if not community_props:
             # Fall back to candidateprop if set, else default single community_id
-            if dim.candidateprop:
-                community_props = [dim.candidateprop]
-            else:
-                community_props = ["community_id"]
+            community_props = [dim.candidateprop] if dim.candidateprop else ["community_id"]
 
         # Build CASE expressions for each community property
         match_cases = []
@@ -575,14 +574,11 @@ class ScoringAssembler:
     def _leaky_relu(expr: str, negative_slope: float = 0.02) -> str:
         """S2-02: LeakyReLU activation between propagation passes.
 
-        HGKR Eq. 5: LeakyReLU with α=0.02 prevents signal collapse.
+        HGKR Eq. 5: LeakyReLU with a=0.02 prevents signal collapse.
         Standard ReLU zeros out negative signals permanently; LeakyReLU
         allows weak negative contribution.
         """
-        return (
-            f"CASE WHEN ({expr}) >= 0 THEN ({expr}) "
-            f"ELSE {negative_slope} * ({expr}) END"
-        )
+        return f"CASE WHEN ({expr}) >= 0 THEN ({expr}) ELSE {negative_slope} * ({expr}) END"
 
     def _build_score_expression(self, weight_exprs: list[str]) -> str:
         if not weight_exprs:

--- a/engine/scoring/confidence.py
+++ b/engine/scoring/confidence.py
@@ -200,9 +200,7 @@ class ConfidenceChecker:
 
         # S2-07: Also check dimensional agreement
         agreement_flags = self.check_dimensional_agreement(candidates)
-        agreement_map: dict[int, dict[str, Any]] = {
-            f["candidate_index"]: f for f in agreement_flags
-        }
+        agreement_map: dict[int, dict[str, Any]] = {f["candidate_index"]: f for f in agreement_flags}
 
         for idx, candidate in enumerate(candidates):
             flags_list: list[str] = []

--- a/engine/scoring/helpfulness.py
+++ b/engine/scoring/helpfulness.py
@@ -68,7 +68,7 @@ class HelpfulnessScorer:
 
         scorer = HelpfulnessScorer(alpha=0.5)
         result = scorer.compute(similarity=0.82, importance=0.45)
-        print(result.score)  # 0.635
+        score = result.score  # 0.635
     """
 
     def __init__(self, alpha: float = 0.5) -> None:

--- a/engine/scoring/importance.py
+++ b/engine/scoring/importance.py
@@ -64,7 +64,7 @@ class ImportanceScorer:
         scorer = ImportanceScorer()
         visit_counts = {"v1": 5, "v2": 3, "v3": 2}
         result = scorer.compute("v1", visit_counts)
-        print(result.score)  # 0.5
+        score = result.score  # 0.5
     """
 
     def compute(
@@ -118,10 +118,7 @@ class ImportanceScorer:
 
         total = sum(visit_counts.values())
         if total == 0:
-            return {
-                vid: ImportanceResult(score=0.0, visit_count=0, total_visits=0)
-                for vid in visit_counts
-            }
+            return {vid: ImportanceResult(score=0.0, visit_count=0, total_visits=0) for vid in visit_counts}
 
         results: dict[str, ImportanceResult] = {}
         for vid, count in visit_counts.items():

--- a/engine/scoring/pareto_integrator.py
+++ b/engine/scoring/pareto_integrator.py
@@ -22,6 +22,7 @@ primitives.  Provides:
 3. ``apply_constraint_penalties()`` — enforces hard/soft constraints from
    the ``DecisionArbitrationSpec``
 """
+
 from __future__ import annotations
 
 import logging
@@ -136,10 +137,9 @@ def apply_constraint_penalties(
                 if is_hard:
                     rejected = True
                     break
-                else:
-                    # Apply soft penalty to the overall score
-                    if "score" in candidate:
-                        candidate["score"] = candidate["score"] * penalty
+                # Apply soft penalty to the overall score
+                if "score" in candidate:
+                    candidate["score"] = candidate["score"] * penalty
 
         if not rejected:
             filtered.append(candidate)
@@ -182,9 +182,7 @@ def apply_pareto_filter(
         ``frontsize`` — number of non-dominated candidates
         ``pruned_pct`` — percentage of candidates pruned
     """
-    pareto_candidates = build_pareto_candidates(
-        candidates, dimension_names, candidate_id_key=candidate_id_key
-    )
+    pareto_candidates = build_pareto_candidates(candidates, dimension_names, candidate_id_key=candidate_id_key)
 
     if not pareto_candidates:
         return {

--- a/engine/scoring/weight_discovery.py
+++ b/engine/scoring/weight_discovery.py
@@ -26,6 +26,7 @@ Usage::
         n_samples=50,
     )
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -72,7 +73,7 @@ async def adaptive_weight_discovery(
 
     # Build uniform baseline from dimension names
     k = len(dimension_names)
-    current_weights = {d: 1.0 / k for d in dimension_names}
+    current_weights = dict.fromkeys(dimension_names, 1.0 / k)
 
     # Delegate CPU-bound work to thread pool
     loop = asyncio.get_running_loop()
@@ -88,8 +89,7 @@ async def adaptive_weight_discovery(
     )
 
     logger.info(
-        "Adaptive weight discovery: %d Pareto-optimal vectors from %d samples "
-        "(pruned %.1f%%)",
+        "Adaptive weight discovery: %d Pareto-optimal vectors from %d samples (pruned %.1f%%)",
         len(front),
         n_samples,
         round((1.0 - len(front) / max(n_samples, 1)) * 100, 1),

--- a/engine/security/P2_9_llm_schemas.py
+++ b/engine/security/P2_9_llm_schemas.py
@@ -31,10 +31,10 @@ import re
 from typing import Any, TypeVar
 
 import structlog
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 # These come from P1-5 (engine/security/llm.py)
 from engine.security.llm import sanitize_llm_input, track_llm_usage
-from pydantic import BaseModel, Field, ValidationError, field_validator
 
 logger = logging.getLogger(__name__)
 _slog = structlog.get_logger(__name__)
@@ -135,10 +135,7 @@ class _LLMBackend:
         try:
             from openai import OpenAI
         except ImportError as exc:
-            raise RuntimeError(
-                "openai package is required for LLM features. "
-                "Install with: pip install openai"
-            ) from exc
+            raise RuntimeError("openai package is required for LLM features. Install with: pip install openai") from exc
 
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
@@ -240,6 +237,7 @@ class ValidatedLLMClient:
         except RuntimeError as exc:
             # Convert to FeatureNotEnabled for graceful degradation
             from chassis.errors import FeatureNotEnabled
+
             raise FeatureNotEnabled(
                 "LLM SDK",
                 flag="OPENAI_API_KEY",

--- a/engine/startup_wiring.py
+++ b/engine/startup_wiring.py
@@ -3,9 +3,12 @@ GAP-FIX STARTUP WIRING
 Add these calls to your application lifespan / startup handler in order.
 This file is a recipe — adapt paths to match your actual app entrypoint.
 """
+
 from __future__ import annotations
-import asyncpg
+
 import logging
+
+import asyncpg
 
 logger = logging.getLogger(__name__)
 
@@ -14,19 +17,21 @@ async def apply_all_gap_fixes(pg_dsn: str, neo4j_driver, domain_pack_loader) -> 
     """
     Call once during application startup, before serving requests.
     Parameters:
-        pg_dsn            – asyncpg-compatible DSN string
-        neo4j_driver      – AsyncDriver from neo4j-driver
-        domain_pack_loader – DomainPackLoader instance
+        pg_dsn            - asyncpg-compatible DSN string
+        neo4j_driver      - AsyncDriver from neo4j-driver
+        domain_pack_loader - DomainPackLoader instance
     """
 
     # ── Gap 5: Wire PostgreSQL audit pool ────────────────────────────────────
     from shared.audit_persistence import configure_audit_pool
+
     pg_pool = await asyncpg.create_pool(pg_dsn, min_size=2, max_size=10)
     await configure_audit_pool(pg_pool)
     logger.info("startup: Gap-5 audit pool wired")
 
     # ── Gap 3: Load domain KB rules into inference registry ──────────────────
     from engine.inference_rule_registry import load_domain_rules
+
     for domain_id in domain_pack_loader.list_domains():
         spec = domain_pack_loader.load_domain(domain_id)
         if spec and spec.kb:
@@ -35,18 +40,19 @@ async def apply_all_gap_fixes(pg_dsn: str, neo4j_driver, domain_pack_loader) -> 
 
     # ── Gap 2: Initialise GRAPH→ENRICH return channel ────────────────────────
     from engine.graph_return_channel import GraphToEnrichReturnChannel
+
     GraphToEnrichReturnChannel.get_instance()
     logger.info("startup: Gap-2 return channel initialised")
 
     # ── Gap 6: Register community-export hook on GDS scheduler ───────────────
     from graph.community_export import export_community_labels_to_enrich
+
     try:
         from graph.gds_scheduler import GDSScheduler
+
         GDSScheduler.register_post_job_hook(
             job_type="louvain",
-            hook=lambda tenant_id, domain_id: export_community_labels_to_enrich(
-                neo4j_driver, tenant_id, domain_id
-            ),
+            hook=lambda tenant_id, domain_id: export_community_labels_to_enrich(neo4j_driver, tenant_id, domain_id),
         )
         logger.info("startup: Gap-6 community export hook registered")
     except ImportError:

--- a/engine/state.py
+++ b/engine/state.py
@@ -197,7 +197,7 @@ _ENGINE_STATE: EngineState | None = None
 
 def get_state() -> EngineState:
     """Return the process-singleton EngineState instance (lazy-created)."""
-    global _ENGINE_STATE  # noqa: PLW0603
+    global _ENGINE_STATE
     if _ENGINE_STATE is None:
         _ENGINE_STATE = EngineState()
     return _ENGINE_STATE
@@ -205,7 +205,7 @@ def get_state() -> EngineState:
 
 def _reset_singleton() -> None:
     """Reset the process-singleton for test isolation. Do NOT call in production."""
-    global _ENGINE_STATE  # noqa: PLW0603
+    global _ENGINE_STATE
     if _ENGINE_STATE is not None:
         _ENGINE_STATE.reset()
     _ENGINE_STATE = None

--- a/engine/traversal/edge_merger.py
+++ b/engine/traversal/edge_merger.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass, field
-from typing import Any
 
 import numpy as np
 
@@ -119,7 +118,7 @@ class EdgeMerger:
             incoming_triplets=target_triplets,
             vertex_count=1000,
         )
-        print(len(result.edges))  # <= n * log(n)
+        edge_count = len(result.edges)  # <= n * log(n)
     """
 
     def __init__(
@@ -205,9 +204,7 @@ class EdgeMerger:
 
         # Infer vertex count if not provided
         if vertex_count is None:
-            vertex_ids = {t.vertex_id for t in outgoing_triplets} | {
-                t.vertex_id for t in incoming_triplets
-            }
+            vertex_ids = {t.vertex_id for t in outgoing_triplets} | {t.vertex_id for t in incoming_triplets}
             vertex_count = len(vertex_ids)
 
         density_limit = self.compute_density_limit(vertex_count)

--- a/engine/traversal/multihop.py
+++ b/engine/traversal/multihop.py
@@ -158,7 +158,7 @@ class MultiHopTraverser:
             start_vertices=["v1", "v2", "v3"],
             query_embedding=query_emb,
         )
-        print(result.visit_counts)  # {"v1": 3, "v4": 2, ...}
+        visit_counts = result.visit_counts  # {"v1": 3, "v4": 2, ...}
     """
 
     def __init__(
@@ -203,7 +203,7 @@ class MultiHopTraverser:
         self._max_llm_calls = max_llm_calls
         self._llm_client = llm_client
 
-    async def traverse(
+    async def traverse(  # noqa: PLR0915
         self,
         start_vertices: list[str],
         query_embedding: np.ndarray | None = None,
@@ -282,21 +282,18 @@ class MultiHopTraverser:
 
                 if self._mode == ReasoningMode.SIMILARITY:
                     selected_edge = self._select_by_similarity(
-                        query_embedding, edges  # type: ignore[arg-type]
+                        query_embedding,
+                        edges,  # type: ignore[arg-type]
                     )
                 elif self._mode == ReasoningMode.LLM:
                     if llm_calls >= self._max_llm_calls:
                         # Fall back to similarity when LLM budget exhausted
                         if query_embedding is not None:
-                            selected_edge = self._select_by_similarity(
-                                query_embedding, edges
-                            )
+                            selected_edge = self._select_by_similarity(query_embedding, edges)
                         else:
                             selected_edge = edges[0] if edges else None
                     else:
-                        selected_edge = self._select_by_llm(
-                            query_text, vertex_id, edges
-                        )
+                        selected_edge = self._select_by_llm(query_text, vertex_id, edges)
                         llm_calls += 1
 
                 if selected_edge is not None:
@@ -389,10 +386,7 @@ class MultiHopTraverser:
         if not edges or self._llm_client is None:
             return None
 
-        edge_dicts = [
-            {"question": e.question, "target_id": e.target_id}
-            for e in edges
-        ]
+        edge_dicts = [{"question": e.question, "target_id": e.target_id} for e in edges]
 
         try:
             selected_idx = self._llm_client.evaluate_edges(

--- a/engine/traversal/pseudo_query.py
+++ b/engine/traversal/pseudo_query.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -182,8 +182,8 @@ class PseudoQueryGenerator:
             n_incoming=2,
             m_outgoing=4,
         )
-        print(len(result.incoming))   # 2
-        print(len(result.outgoing))   # 4
+        incoming_count = len(result.incoming)  # 2
+        outgoing_count = len(result.outgoing)  # 4
     """
 
     def __init__(

--- a/l9_core/models.py
+++ b/l9_core/models.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from hashlib import sha256
 import json
+from datetime import UTC, datetime
+from hashlib import sha256
 from typing import Any
 from uuid import uuid4
 
@@ -32,7 +32,7 @@ class PacketEnvelope(BaseModel):
     tenant: TenantContext
     payload: dict[str, Any]
     lineage: PacketLineage
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     content_hash: str = ""
 
     @field_validator("packet_type")
@@ -60,7 +60,7 @@ class PacketEnvelope(BaseModel):
         )
         return sha256(canonical_json.encode("utf-8")).hexdigest()
 
-    def derive(self, packet_type: str, payload: dict[str, Any]) -> "PacketEnvelope":
+    def derive(self, packet_type: str, payload: dict[str, Any]) -> PacketEnvelope:
         return PacketEnvelope(
             packet_type=packet_type,
             tenant=self.tenant,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ RULE 7 (L9 Contract): DomainPackLoader is instantiated with
 DOMAINS_DIR uses Path(__file__).parent.parent to resolve
 from tests/ → repo root → domains/.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -37,6 +38,7 @@ DOMAINS_DIR: Path = Path(__file__).parent.parent / "domains"
 
 # ── Event Loop ─────────────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="session")
 def event_loop():
     """Session-scoped event loop for all async tests."""
@@ -46,6 +48,7 @@ def event_loop():
 
 
 # ── Neo4j Testcontainer ────────────────────────────────────────────────────────
+
 
 @pytest.fixture(scope="session")
 def neo4j_container():
@@ -82,6 +85,7 @@ def neo4j_container():
 
 # ── Graph Driver ───────────────────────────────────────────────────────────────
 
+
 @pytest_asyncio.fixture(scope="session")
 async def graph_driver(neo4j_container) -> AsyncGenerator:
     """
@@ -105,9 +109,7 @@ async def graph_driver(neo4j_container) -> AsyncGenerator:
         parameters={"id": "smoke-probe"},
         database="neo4j",
     )
-    assert result.get("nodes_created", 0) == 1, (
-        f"Smoke write failed — Neo4j driver not live. Result: {result}"
-    )
+    assert result.get("nodes_created", 0) == 1, f"Smoke write failed — Neo4j driver not live. Result: {result}"
     # Clean up smoke node
     await driver.execute_write(
         cypher="MATCH (n:_SmokeTest) DETACH DELETE n",
@@ -121,14 +123,17 @@ async def graph_driver(neo4j_container) -> AsyncGenerator:
 
 # ── DomainPackLoader ───────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="session")
 def domain_loader():
     """Session-scoped domain loader — RULE 7: exact signature."""
     from engine.config.loader import DomainPackLoader
+
     return DomainPackLoader(domains_dir=DOMAINS_DIR)
 
 
 # ── Domain Spec ────────────────────────────────────────────────────────────────
+
 
 @pytest.fixture(scope="session")
 def domain_spec(domain_loader):
@@ -140,6 +145,7 @@ def domain_spec(domain_loader):
 def minimal_domain_spec():
     """Minimal in-memory domain spec for unit tests that don't need full YAML."""
     from engine.config.schema import DomainSpec
+
     raw = {
         "domain": {"id": "test", "name": "Test Domain", "version": "0.0.1"},
         "ontology": {
@@ -170,6 +176,7 @@ def minimal_domain_spec():
 
 # ── Test Isolation ─────────────────────────────────────────────────────────────
 
+
 @pytest_asyncio.fixture(autouse=False)
 async def clean_db(graph_driver) -> AsyncGenerator[None, None]:
     """Wipe all nodes after each integration test that opts in."""
@@ -182,6 +189,7 @@ async def clean_db(graph_driver) -> AsyncGenerator[None, None]:
 
 
 # ── Tenant Fixtures ────────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def test_tenant() -> str:

--- a/tests/contracts/test_contracts.py
+++ b/tests/contracts/test_contracts.py
@@ -9,12 +9,15 @@ without requiring a running Neo4j instance.
 from __future__ import annotations
 
 import ast
-import importlib
 import inspect
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from engine.config.schema import DomainSpec
 
 # Root directories
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -53,7 +56,7 @@ def _read_imports(filepath: Path) -> list[str]:
 
 
 # ============================================================================
-# LAYER 1 — CHASSIS BOUNDARY (contracts 1–5)
+# LAYER 1 - CHASSIS BOUNDARY (contracts 1-5)
 # ============================================================================
 
 
@@ -174,7 +177,7 @@ class TestContract05InfrastructureIsTemplate:
 
 
 # ============================================================================
-# LAYER 2 — PACKET PROTOCOL (contracts 6–8)
+# LAYER 2 - PACKET PROTOCOL (contracts 6-8)
 # ============================================================================
 
 
@@ -261,7 +264,7 @@ class TestContract08LineageAudit:
 
 
 # ============================================================================
-# LAYER 3 — SECURITY (contracts 9–11)
+# LAYER 3 - SECURITY (contracts 9-11)
 # ============================================================================
 
 
@@ -323,16 +326,17 @@ class TestContract10ProhibitedFactors:
         from engine.compliance.prohibited_factors import ProhibitedFactorValidator
         from engine.config.schema import (
             ComplianceSpec,
-            DomainSpec,
             GateSpec,
             GateType,
             ProhibitedFactorsSpec,
         )
 
         blocked_fields = ["race", "ethnicity", "religion", "gender", "age", "disability"]
-        spec = _build_minimal_spec(extra_gates=[
-            GateSpec(name="bad_gate", type=GateType.BOOLEAN, candidateprop="race", queryparam="race"),
-        ])
+        spec = _build_minimal_spec(
+            extra_gates=[
+                GateSpec(name="bad_gate", type=GateType.BOOLEAN, candidateprop="race", queryparam="race"),
+            ]
+        )
         # Add compliance config with prohibited factors
         spec = spec.model_copy(
             update={
@@ -364,20 +368,18 @@ class TestContract11PIIHandling:
     def test_no_pii_logging_in_engine(self):
         """Engine should not log known PII field names as values."""
         pii_log_patterns = [
-            r'logger\.\w+\(.*ssn.*=',
-            r'logger\.\w+\(.*social_security.*=',
-            r'logger\.\w+\(.*password.*=',
+            r"logger\.\w+\(.*ssn.*=",
+            r"logger\.\w+\(.*social_security.*=",
+            r"logger\.\w+\(.*password.*=",
         ]
         for f in _engine_py_files():
             content = f.read_text(encoding="utf-8")
             for pat in pii_log_patterns:
-                assert not re.search(pat, content, re.IGNORECASE), (
-                    f"{f.relative_to(ROOT)} may log PII: {pat}"
-                )
+                assert not re.search(pat, content, re.IGNORECASE), f"{f.relative_to(ROOT)} may log PII: {pat}"
 
 
 # ============================================================================
-# LAYER 4 — ENGINE ARCHITECTURE (contracts 12–16)
+# LAYER 4 - ENGINE ARCHITECTURE (contracts 12-16)
 # ============================================================================
 
 
@@ -415,9 +417,15 @@ class TestContract13GateThenScore:
         from engine.config.schema import ComputationType
 
         expected = {
-            "geodecay", "lognormalized", "communitymatch", "inverselinear",
-            "candidateproperty", "weightedrate", "pricealignment",
-            "temporalproximity", "customcypher",
+            "geodecay",
+            "lognormalized",
+            "communitymatch",
+            "inverselinear",
+            "candidateproperty",
+            "weightedrate",
+            "pricealignment",
+            "temporalproximity",
+            "customcypher",
         }
         actual = {ct.value for ct in ComputationType}
         assert expected.issubset(actual), f"Missing computation types: {expected - actual}"
@@ -428,12 +436,15 @@ class TestContract13GateThenScore:
         from engine.config.schema import GateSpec, GateType
         from engine.gates.compiler import GateCompiler
 
-        spec = _build_minimal_spec(extra_gates=[
-            GateSpec(name="test_bool", type=GateType.BOOLEAN, candidateprop="active", queryparam="is_active"),
-        ])
+        spec = _build_minimal_spec(
+            extra_gates=[
+                GateSpec(name="test_bool", type=GateType.BOOLEAN, candidateprop="active", queryparam="is_active"),
+            ]
+        )
         compiler = GateCompiler(spec)
         result = compiler.compile_all_gates("buyer_to_seller")
-        assert result and result != "true"
+        assert result
+        assert result != "true"
 
     @pytest.mark.contract
     def test_scoring_assembles_with_clause(self):
@@ -503,15 +514,17 @@ class TestContract15BidirectionalMatching:
         from engine.config.schema import GateSpec, GateType
         from engine.gates.compiler import GateCompiler
 
-        spec = _build_minimal_spec(extra_gates=[
-            GateSpec(
-                name="directional",
-                type=GateType.BOOLEAN,
-                candidateprop="active",
-                queryparam="is_active",
-                matchdirections=["buyer_to_seller"],
-            ),
-        ])
+        spec = _build_minimal_spec(
+            extra_gates=[
+                GateSpec(
+                    name="directional",
+                    type=GateType.BOOLEAN,
+                    candidateprop="active",
+                    queryparam="is_active",
+                    matchdirections=["buyer_to_seller"],
+                ),
+            ]
+        )
         compiler = GateCompiler(spec)
         # Should compile for matching direction
         result_match = compiler.compile_all_gates("buyer_to_seller")
@@ -525,8 +538,16 @@ class TestContract16FileStructure:
     """CONTRACT 16: Fixed file structure layout."""
 
     EXPECTED_DIRS = [
-        "config", "gates", "scoring", "traversal", "sync",
-        "gds", "graph", "compliance", "packet", "utils",
+        "config",
+        "gates",
+        "scoring",
+        "traversal",
+        "sync",
+        "gds",
+        "graph",
+        "compliance",
+        "packet",
+        "utils",
     ]
 
     @pytest.mark.contract
@@ -544,18 +565,23 @@ class TestContract16FileStructure:
         """Engine contains only expected subdirectories (plus known extensions)."""
         # Core dirs from contract 16 + known extensions added in Waves 1-4
         allowed = set(self.EXPECTED_DIRS) | {
-            "__pycache__", "kge", "security", "health", "personas",
-            "intake", "causal", "feedback", "resolution",
+            "__pycache__",
+            "kge",
+            "security",
+            "health",
+            "personas",
+            "intake",
+            "causal",
+            "feedback",
+            "resolution",
         }
         for item in ENGINE_DIR.iterdir():
             if item.is_dir() and not item.name.startswith("."):
-                assert item.name in allowed, (
-                    f"Unexpected directory in engine/: {item.name}"
-                )
+                assert item.name in allowed, f"Unexpected directory in engine/: {item.name}"
 
 
 # ============================================================================
-# LAYER 5 — TESTING + QUALITY (contracts 17–18)
+# LAYER 5 - TESTING + QUALITY (contracts 17-18)
 # ============================================================================
 
 
@@ -594,7 +620,7 @@ class TestContract18L9Meta:
 
 
 # ============================================================================
-# LAYER 6 — GRAPH INTELLIGENCE (contracts 19–20)
+# LAYER 6 - GRAPH INTELLIGENCE (contracts 19-20)
 # ============================================================================
 
 
@@ -647,11 +673,15 @@ class TestContract20KGEEmbeddings:
 # ============================================================================
 
 
-def _build_minimal_spec(extra_gates: list | None = None) -> "DomainSpec":
+def _build_minimal_spec(extra_gates: list | None = None) -> DomainSpec:
     """Build a minimal DomainSpec for testing without YAML."""
     from engine.config.schema import (
         DomainMetadata,
         DomainSpec,
+        EdgeCategory,
+        EdgeDirection,
+        EdgeSpec,
+        ManagedByType,
         MatchEntitiesSpec,
         MatchEntitySpec,
         NodeSpec,
@@ -660,14 +690,7 @@ def _build_minimal_spec(extra_gates: list | None = None) -> "DomainSpec":
         PropertyType,
         QueryFieldSpec,
         QuerySchemaSpec,
-        ScoringDimensionSpec,
-        ScoringSource,
         ScoringSpec,
-        ComputationType,
-        EdgeDirection,
-        EdgeCategory,
-        EdgeSpec,
-        ManagedByType,
     )
 
     nodes = [
@@ -717,7 +740,7 @@ def _build_minimal_spec(extra_gates: list | None = None) -> "DomainSpec":
     )
 
 
-def _build_minimal_spec_with_scoring() -> "DomainSpec":
+def _build_minimal_spec_with_scoring() -> DomainSpec:
     """Build a minimal DomainSpec with scoring dimensions."""
     from engine.config.schema import (
         ComputationType,

--- a/tests/gap_fixes/test_gap1_contract.py
+++ b/tests/gap_fixes/test_gap1_contract.py
@@ -1,6 +1,7 @@
 """
 Tests for GAP-1: contract_enforcement.py
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gap_fixes/test_gap2_return_channel.py
+++ b/tests/gap_fixes/test_gap2_return_channel.py
@@ -1,6 +1,7 @@
 """
 Tests for GAP-2: graph_return_channel.py
 """
+
 from __future__ import annotations
 
 import pytest
@@ -46,9 +47,7 @@ async def test_submit_and_drain() -> None:
 async def test_low_confidence_filtered() -> None:
     envelope = build_graph_inference_result_envelope(
         tenant_id="acme",
-        inference_outputs=[
-            {"entity_id": "e1", "field": "x", "value": "v", "confidence": 0.30, "rule": "r1"}
-        ],
+        inference_outputs=[{"entity_id": "e1", "field": "x", "value": "v", "confidence": 0.30, "rule": "r1"}],
     )
     channel = GraphToEnrichReturnChannel.get_instance()
     count = await channel.submit(envelope)
@@ -59,12 +58,11 @@ async def test_low_confidence_filtered() -> None:
 async def test_tampered_envelope_rejected() -> None:
     envelope = build_graph_inference_result_envelope(
         tenant_id="acme",
-        inference_outputs=[
-            {"entity_id": "e1", "field": "x", "value": "v", "confidence": 0.9, "rule": "r"}
-        ],
+        inference_outputs=[{"entity_id": "e1", "field": "x", "value": "v", "confidence": 0.9, "rule": "r"}],
     )
     # Tamper with content after hashes are set
     import dataclasses
+
     tampered = dataclasses.replace(
         envelope,
         inference_outputs=[{"entity_id": "e_TAMPERED"}],

--- a/tests/gap_fixes/test_gap3_inference_registry.py
+++ b/tests/gap_fixes/test_gap3_inference_registry.py
@@ -1,6 +1,7 @@
 """
 Tests for GAP-3: inference_rule_registry.py
 """
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gap_fixes/test_gap5_audit.py
+++ b/tests/gap_fixes/test_gap5_audit.py
@@ -1,10 +1,11 @@
 """
 Tests for GAP-5: audit_persistence.py
 """
+
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -46,7 +47,9 @@ async def test_flush_inserts_rows() -> None:
     mock_conn.executemany = AsyncMock()
 
     mock_pool = MagicMock()
-    mock_pool.acquire = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_conn), __aexit__=AsyncMock(return_value=False)))
+    mock_pool.acquire = MagicMock(
+        return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_conn), __aexit__=AsyncMock(return_value=False))
+    )
     audit_persistence._POOL = mock_pool
 
     result = await audit_persistence.flush_audit_entries(entries)

--- a/tests/integration/test_admin_handler.py
+++ b/tests/integration/test_admin_handler.py
@@ -1,4 +1,5 @@
 """Integration tests — admin handler: list_domains, get_domain, init_schema."""
+
 from __future__ import annotations
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_list_domains_returns_plasticos(graph_driver, domain_loader):
     from engine.handlers import handle_admin
+
     result = await handle_admin(
         "plasticos",
         {"sub_action": "list_domains"},
@@ -19,6 +21,7 @@ async def test_list_domains_returns_plasticos(graph_driver, domain_loader):
 @pytest.mark.asyncio
 async def test_get_domain_returns_spec(graph_driver, domain_loader):
     from engine.handlers import handle_admin
+
     result = await handle_admin(
         "plasticos",
         {"sub_action": "get_domain", "domain_id": "plasticos"},
@@ -32,6 +35,7 @@ async def test_get_domain_returns_spec(graph_driver, domain_loader):
 async def test_admin_missing_domain_id_handled(graph_driver, domain_loader):
     """get_domain without domain_id should raise or return error."""
     from engine.handlers import handle_admin
+
     try:
         result = await handle_admin(
             "plasticos",

--- a/tests/integration/test_graph_driver.py
+++ b/tests/integration/test_graph_driver.py
@@ -1,4 +1,5 @@
 """Integration tests — GraphDriver: write, read, empty result."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/integration/test_handlers.py
+++ b/tests/integration/test_handlers.py
@@ -1,10 +1,9 @@
-from pathlib import Path
 import asyncio
+from pathlib import Path
 
 from engine.config.loader import DomainSpecLoader
 from engine.graph.driver import GraphDriver
 from engine.handlers import handle_admin, handle_match, handle_sync, init_dependencies
-
 
 SPEC_PATH = Path("domains/plasticos/spec.yaml")
 

--- a/tests/integration/test_hoprag_pipeline.py
+++ b/tests/integration/test_hoprag_pipeline.py
@@ -22,7 +22,6 @@ These tests use mock implementations for external dependencies
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import numpy as np
@@ -34,11 +33,12 @@ from engine.scoring.importance import ImportanceScorer
 from engine.traversal.edge_merger import EdgeMerger, EdgeTriplet
 from engine.traversal.multihop import (
     MultiHopTraverser,
-    ReasoningMode as TraversalReasoningMode,
     TraversalEdge,
 )
+from engine.traversal.multihop import (
+    ReasoningMode as TraversalReasoningMode,
+)
 from engine.traversal.pseudo_query import PseudoQueryGenerator
-
 
 # ── Mock Implementations ─────────────────────────────────────────────
 
@@ -49,7 +49,7 @@ class MockLLM:
     def generate(self, prompt: str) -> str:
         if "exactly 2" in prompt:
             return "1. What is the main topic?\n2. What are the key findings?"
-        elif "exactly 4" in prompt:
+        if "exactly 4" in prompt:
             return (
                 "1. How does this relate to other research?\n"
                 "2. What are the implications?\n"
@@ -318,7 +318,9 @@ class TestEndToEndScenario:
             ],
             "biology": [],
             "quantum": [
-                TraversalEdge("quantum", "chemistry", "How does quantum mechanics apply to chemistry?", embedding=emb_chemistry),
+                TraversalEdge(
+                    "quantum", "chemistry", "How does quantum mechanics apply to chemistry?", embedding=emb_chemistry
+                ),
             ],
             "organic": [],
         }

--- a/tests/integration/test_match_handler.py
+++ b/tests/integration/test_match_handler.py
@@ -1,4 +1,5 @@
 """Integration tests — match handler: full pipeline, top_n, invalid payload."""
+
 from __future__ import annotations
 
 import pytest
@@ -13,27 +14,30 @@ async def test_match_returns_candidates(graph_driver, domain_loader, clean_db):
         SET n += row
         SET n.synced_at = datetime()
         """,
-        parameters={"batch": [
-            {
-                "id": "f1",
-                "name": "Alpha Recycle",
-                "contamination_tolerance": 0.05,
-                "latitude": 34.05,
-                "longitude": -118.24,
-                "reinforcement_score": 0.7,
-            },
-            {
-                "id": "f2",
-                "name": "Beta Process",
-                "contamination_tolerance": 0.10,
-                "latitude": 34.10,
-                "longitude": -118.30,
-                "reinforcement_score": 0.5,
-            },
-        ]},
+        parameters={
+            "batch": [
+                {
+                    "id": "f1",
+                    "name": "Alpha Recycle",
+                    "contamination_tolerance": 0.05,
+                    "latitude": 34.05,
+                    "longitude": -118.24,
+                    "reinforcement_score": 0.7,
+                },
+                {
+                    "id": "f2",
+                    "name": "Beta Process",
+                    "contamination_tolerance": 0.10,
+                    "latitude": 34.10,
+                    "longitude": -118.30,
+                    "reinforcement_score": 0.5,
+                },
+            ]
+        },
         database="neo4j",
     )
     from engine.handlers import handle_match
+
     result = await handle_match(
         "plasticos",
         {
@@ -61,13 +65,13 @@ async def test_match_respects_top_n(graph_driver, domain_loader, clean_db):
         MERGE (n:Facility {id: row.id})
         SET n += row
         """,
-        parameters={"batch": [
-            {"id": f"f{i}", "name": f"Facility {i}", "contamination_tolerance": 0.05}
-            for i in range(5)
-        ]},
+        parameters={
+            "batch": [{"id": f"f{i}", "name": f"Facility {i}", "contamination_tolerance": 0.05} for i in range(5)]
+        },
         database="neo4j",
     )
     from engine.handlers import handle_match
+
     result = await handle_match(
         "plasticos",
         {"query": {}, "match_direction": "*", "top_n": 2},
@@ -82,6 +86,7 @@ def test_match_invalid_top_n_raises():
     try:
         from engine.models.payloads import MatchPayload
         from pydantic import ValidationError
+
         with pytest.raises(ValidationError):
             MatchPayload.model_validate({"match_direction": "*", "top_n": -5})
     except ImportError:

--- a/tests/integration/test_outcomes_handler.py
+++ b/tests/integration/test_outcomes_handler.py
@@ -1,4 +1,5 @@
 """Integration tests — outcomes handler: SUCCEEDED, REJECTED, validation."""
+
 from __future__ import annotations
 
 import pytest
@@ -12,6 +13,7 @@ async def test_outcome_success_recorded(graph_driver, clean_db):
         database="neo4j",
     )
     from engine.handlers import handle_outcomes
+
     result = await handle_outcomes(
         "plasticos",
         {
@@ -33,6 +35,7 @@ async def test_outcome_rejected_recorded(graph_driver, clean_db):
         database="neo4j",
     )
     from engine.handlers import handle_outcomes
+
     result = await handle_outcomes(
         "plasticos",
         {
@@ -50,6 +53,7 @@ def test_outcome_invalid_payload_raises():
     try:
         from engine.models.payloads import OutcomePayload
         from pydantic import ValidationError
+
         with pytest.raises(ValidationError):
             OutcomePayload.model_validate({"was_selected": "yes_please"})
     except ImportError:

--- a/tests/integration/test_sync_handler.py
+++ b/tests/integration/test_sync_handler.py
@@ -1,4 +1,5 @@
 """Integration tests — sync handler: merge, idempotency, unknown entity."""
+
 from __future__ import annotations
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_sync_merges_facilities(graph_driver, domain_loader, clean_db):
     from engine.handlers import handle_sync
+
     result = await handle_sync(
         "plasticos",
         {
@@ -25,6 +27,7 @@ async def test_sync_merges_facilities(graph_driver, domain_loader, clean_db):
 @pytest.mark.asyncio
 async def test_sync_idempotent_on_second_call(graph_driver, domain_loader, clean_db):
     from engine.handlers import handle_sync
+
     payload = {
         "entity_type": "facilities",
         "batch": [{"id": "fac-idem", "name": "Idem Facility"}],
@@ -38,6 +41,7 @@ async def test_sync_idempotent_on_second_call(graph_driver, domain_loader, clean
 def test_sync_unknown_entity_type_raises(domain_loader):
     """RULE 3: unknown entity_type raises, not silent pass-through."""
     from engine.sync.generator import SyncGenerator
+
     spec = domain_loader.load_domain("plasticos")
     gen = SyncGenerator(spec)
     with pytest.raises(Exception):

--- a/tests/invariants/test_compliance.py
+++ b/tests/invariants/test_compliance.py
@@ -8,7 +8,6 @@ fixes from Wave 1-4 remain in place.
 from __future__ import annotations
 
 import inspect
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -27,8 +26,10 @@ class TestT301GDSSchedulerStart:
         """Manual trigger_gds must be available."""
         from engine.gds.scheduler import GDSScheduler
 
-        assert hasattr(GDSScheduler, "trigger_job") or hasattr(GDSScheduler, "trigger_gds") or hasattr(
-            GDSScheduler, "run_job"
+        assert (
+            hasattr(GDSScheduler, "trigger_job")
+            or hasattr(GDSScheduler, "trigger_gds")
+            or hasattr(GDSScheduler, "run_job")
         ), "GDSScheduler missing manual trigger method"
 
 
@@ -39,9 +40,7 @@ class TestT302AuditFlush:
     def test_flush_audit_is_coroutine(self):
         from engine.compliance.engine import ComplianceEngine
 
-        assert inspect.iscoroutinefunction(ComplianceEngine.flush_audit), (
-            "flush_audit must be async (awaitable)"
-        )
+        assert inspect.iscoroutinefunction(ComplianceEngine.flush_audit), "flush_audit must be async (awaitable)"
 
 
 @pytest.mark.finding("T3-05")

--- a/tests/invariants/test_configuration.py
+++ b/tests/invariants/test_configuration.py
@@ -71,9 +71,7 @@ class TestT503ChassisImportContract:
                 if stripped.startswith("#"):
                     continue
                 if re.match(r"^(from|import)\s+chassis\b", stripped):
-                    pytest.fail(
-                        f"T5-03: {f.relative_to(ROOT)} imports chassis — only {allowed} may do this"
-                    )
+                    pytest.fail(f"T5-03: {f.relative_to(ROOT)} imports chassis — only {allowed} may do this")
 
 
 @pytest.mark.finding("T5-04")

--- a/tests/invariants/test_trust_boundary.py
+++ b/tests/invariants/test_trust_boundary.py
@@ -7,10 +7,9 @@ and asserts the fix prevents it.
 
 from __future__ import annotations
 
-import os
 import re
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -65,10 +64,9 @@ class TestT103TenantIsolation:
 
     def test_tenant_allowlist_rejects_unauthorized(self):
         """_validate_tenant_access raises for tenants not in allowlist."""
-        from engine.handlers import ValidationError, _validate_tenant_access
-
         # Simulate an allowlist
         import engine.handlers as h
+        from engine.handlers import ValidationError, _validate_tenant_access
 
         original = h._tenant_allowlist
         try:
@@ -80,9 +78,8 @@ class TestT103TenantIsolation:
 
     def test_tenant_allowlist_allows_authorized(self):
         """Authorized tenants pass the check."""
-        from engine.handlers import _validate_tenant_access
-
         import engine.handlers as h
+        from engine.handlers import _validate_tenant_access
 
         original = h._tenant_allowlist
         try:
@@ -94,9 +91,8 @@ class TestT103TenantIsolation:
 
     def test_no_allowlist_permits_all(self):
         """When allowlist is None (dev mode), all tenants allowed."""
-        from engine.handlers import _validate_tenant_access
-
         import engine.handlers as h
+        from engine.handlers import _validate_tenant_access
 
         original = h._tenant_allowlist
         try:
@@ -161,7 +157,9 @@ def _build_minimal_spec_for_resolver(derived=None):
             ],
             edges=[
                 EdgeSpec(
-                    type="R", **{"from": "N"}, to="Q",
+                    type="R",
+                    **{"from": "N"},
+                    to="Q",
                     direction=EdgeDirection.DIRECTED,
                     category=EdgeCategory.CAPABILITY,
                     managedby=ManagedByType.SYNC,

--- a/tests/performance/test_query_latency.py
+++ b/tests/performance/test_query_latency.py
@@ -18,6 +18,7 @@ Requires: pytest-benchmark or manual timing.
 from __future__ import annotations
 
 import statistics
+import sys
 import time
 
 import pytest
@@ -87,10 +88,12 @@ class TestMatchQueryLatency:
         p99 = sorted(latencies)[int(len(latencies) * 0.99)]
         avg = statistics.mean(latencies)
 
-        print(f"\n{'─' * 50}")
-        print(f"Match Query Latency (n=50, {len(seeded_graph['facility_ids'])} facilities)")
-        print(f"  avg: {avg:.1f}ms  p50: {p50:.1f}ms  p95: {p95:.1f}ms  p99: {p99:.1f}ms")
-        print(f"{'─' * 50}")
+        sys.stdout.write(
+            f"\n{'─' * 50}\n"
+            f"Match Query Latency (n=50, {len(seeded_graph['facility_ids'])} facilities)\n"
+            f"  avg: {avg:.1f}ms  p50: {p50:.1f}ms  p95: {p95:.1f}ms  p99: {p99:.1f}ms\n"
+            f"{'─' * 50}\n"
+        )
 
         assert p95 < 100, f"p95 latency {p95:.1f}ms exceeds 100ms target"
 
@@ -130,6 +133,6 @@ class TestMatchQueryLatency:
         p95 = sorted(latencies)[int(len(latencies) * 0.95)]
         avg = statistics.mean(latencies)
 
-        print(f"\nRelaxed Match: avg={avg:.1f}ms  p95={p95:.1f}ms")
+        sys.stdout.write(f"\nRelaxed Match: avg={avg:.1f}ms  p95={p95:.1f}ms\n")
 
         assert p95 < 200, f"p95 latency {p95:.1f}ms exceeds 200ms target"

--- a/tests/performance/test_sync_throughput.py
+++ b/tests/performance/test_sync_throughput.py
@@ -17,6 +17,7 @@ Measures entities/second for UNWIND/MERGE sync operations against Neo4j.
 from __future__ import annotations
 
 import statistics
+import sys
 import time
 import uuid
 
@@ -99,11 +100,13 @@ class TestSyncThroughput:
         avg_sec = statistics.mean(latencies)
         throughput = batch_size / avg_sec
 
-        print(f"\n{'─' * 50}")
-        print(f"Sync Throughput: {batch_size} facilities")
-        print(f"  avg: {avg_sec:.2f}s  throughput: {throughput:.0f} entities/sec")
-        print(f"  min: {min(latencies):.2f}s  max: {max(latencies):.2f}s")
-        print(f"{'─' * 50}")
+        sys.stdout.write(
+            f"\n{'─' * 50}\n"
+            f"Sync Throughput: {batch_size} facilities\n"
+            f"  avg: {avg_sec:.2f}s  throughput: {throughput:.0f} entities/sec\n"
+            f"  min: {min(latencies):.2f}s  max: {max(latencies):.2f}s\n"
+            f"{'─' * 50}\n"
+        )
 
         # Verify data landed
         count_result = await graph_driver.execute_query(
@@ -160,8 +163,10 @@ class TestSyncThroughput:
         avg_sec = statistics.mean(latencies)
         throughput = batch_size / avg_sec
 
-        print(f"\nIncremental Update: {batch_size} facilities")
-        print(f"  avg: {avg_sec:.2f}s  throughput: {throughput:.0f} updates/sec")
+        sys.stdout.write(
+            f"\nIncremental Update: {batch_size} facilities\n"
+            f"  avg: {avg_sec:.2f}s  throughput: {throughput:.0f} updates/sec\n"
+        )
 
         # Verify update applied
         result = await graph_driver.execute_query(

--- a/tests/property/test_gates_property.py
+++ b/tests/property/test_gates_property.py
@@ -7,14 +7,11 @@ that compilation always produces safe, well-formed output.
 
 from __future__ import annotations
 
-from hypothesis import given, settings, assume
+from hypothesis import given, settings
 from hypothesis import strategies as st
-
-import pytest
 
 from engine.config.schema import GateSpec, GateType, NullBehavior
 from engine.gates.compiler import GateCompiler
-
 
 # ---------------------------------------------------------------------------
 # Custom Hypothesis strategies
@@ -162,9 +159,7 @@ class TestGateCompilationProperties:
         spec = _build_spec_with_gates([gate])
         compiler = GateCompiler(spec)
         result = compiler.compile(gate)
-        assert result.count("(") == result.count(")"), (
-            f"Unbalanced parens in: {result}"
-        )
+        assert result.count("(") == result.count(")"), f"Unbalanced parens in: {result}"
 
     @given(gate=gate_spec_strategy())
     @settings(max_examples=50, deadline=5000)

--- a/tests/property/test_scoring_property.py
+++ b/tests/property/test_scoring_property.py
@@ -7,13 +7,10 @@ that assembled score expressions maintain [0, 1] bounds and idempotency.
 
 from __future__ import annotations
 
-from hypothesis import given, settings, assume
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
-import pytest
-
 from engine.scoring.assembler import ScoringAssembler
-
 
 # ---------------------------------------------------------------------------
 # Custom strategies
@@ -97,9 +94,7 @@ class TestScoringProperties:
         weighted_sum = sum(weights[i] * scores[i] for i in range(n))
         weight_total = sum(weights[:n])
 
-        assert weighted_sum <= weight_total + 1e-9, (
-            f"Weighted sum {weighted_sum} exceeds weight total {weight_total}"
-        )
+        assert weighted_sum <= weight_total + 1e-9, f"Weighted sum {weighted_sum} exceeds weight total {weight_total}"
 
     def test_clamp_expression_cypher_structure(self):
         """ScoringAssembler._clamp_expression produces valid CASE structure."""
@@ -114,7 +109,6 @@ class TestScoringProperties:
     def test_build_score_expression_empty(self):
         """Empty weight list returns '0.0'."""
         from engine.config.schema import (
-            ComputationType,
             DomainMetadata,
             DomainSpec,
             EdgeCategory,
@@ -125,8 +119,6 @@ class TestScoringProperties:
             MatchEntitySpec,
             NodeSpec,
             OntologySpec,
-            PropertyType,
-            QueryFieldSpec,
             QuerySchemaSpec,
             ScoringSpec,
         )

--- a/tests/scoring/test_benchmark.py
+++ b/tests/scoring/test_benchmark.py
@@ -10,7 +10,6 @@ and using a simple numeric evaluator for score expressions.
 from __future__ import annotations
 
 import math
-import re
 import statistics
 
 import pytest
@@ -37,7 +36,6 @@ from engine.config.schema import (
 )
 from engine.scoring.assembler import ScoringAssembler
 from tests.fixtures.benchmark_data import BAD_PAIRS, GOOD_PAIRS, BenchmarkPair
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/security/test_compliance_security.py
+++ b/tests/security/test_compliance_security.py
@@ -1,24 +1,32 @@
 """
 Security tests — ECOA prohibited factor enforcement at compliance layer.
 """
+
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
 
 DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 
 ECOA_PROHIBITED = [
-    "race", "color", "religion", "national_origin",
-    "sex", "marital_status", "age", "disability",
-    "familial_status", "receipt_of_public_assistance",
+    "race",
+    "color",
+    "religion",
+    "national_origin",
+    "sex",
+    "marital_status",
+    "age",
+    "disability",
+    "familial_status",
+    "receipt_of_public_assistance",
 ]
 
 
 def test_compliance_engine_loads_for_plasticos():
     """ComplianceEngine must load without error for plasticos."""
-    from engine.config.loader import DomainPackLoader
     from engine.compliance.engine import ComplianceEngine
+    from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     engine = ComplianceEngine(spec)
@@ -27,8 +35,9 @@ def test_compliance_engine_loads_for_plasticos():
 
 def test_prohibited_factor_validator_exists():
     """ProhibitedFactorValidator must exist and load from spec."""
-    from engine.config.loader import DomainPackLoader
     from engine.compliance.prohibited_factors import ProhibitedFactorValidator
+    from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     validator = ProhibitedFactorValidator(spec)
@@ -37,24 +46,28 @@ def test_prohibited_factor_validator_exists():
 
 def test_clean_payload_passes_compliance():
     """A payload with no prohibited fields must pass."""
-    from engine.config.loader import DomainPackLoader
     from engine.compliance.engine import ComplianceEngine
+    from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     engine = ComplianceEngine(spec)
-    result = engine.evaluate({
-        "entity_id": "f1",
-        "contamination_tolerance": 0.05,
-        "facility_tier": "mid",
-    })
+    result = engine.evaluate(
+        {
+            "entity_id": "f1",
+            "contamination_tolerance": 0.05,
+            "facility_tier": "mid",
+        }
+    )
     # Should pass without error
     assert result is not None
 
 
 def test_compliance_evaluate_returns_result():
     """evaluate() must return a structured result."""
-    from engine.config.loader import DomainPackLoader
     from engine.compliance.engine import ComplianceEngine
+    from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     engine = ComplianceEngine(spec)

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -4,6 +4,7 @@ Security tests — Cypher injection attempts across parameterized surfaces.
 RULE 4 (L9 Contract): ZERO string interpolation of values in Cypher.
 RULE 3 (L9 Contract): eval/exec/compile are banned.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -23,39 +24,40 @@ INJECTION_STRINGS = [
 @pytest.mark.parametrize("injection", INJECTION_STRINGS)
 def test_sanitize_label_blocks_injection(injection):
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label(injection)
 
 
 def test_sync_generator_uses_parameterized_query():
     """SyncGenerator MUST use $batch param — never interpolate batch values."""
-    from engine.sync.generator import SyncGenerator
-    from engine.config.loader import DomainPackLoader
     from pathlib import Path
-    loader = DomainPackLoader(
-        domains_dir=Path(__file__).parent.parent.parent / "domains"
-    )
+
+    from engine.config.loader import DomainPackLoader
+    from engine.sync.generator import SyncGenerator
+
+    loader = DomainPackLoader(domains_dir=Path(__file__).parent.parent.parent / "domains")
     spec = loader.load_domain("plasticos")
     gen = SyncGenerator(spec)
     if not spec.sync.endpoints:
         pytest.skip("No sync endpoints")
     ep = spec.sync.endpoints[0]
     evil_record = {"id": "'; MATCH (n) DETACH DELETE n RETURN '1"}
-    cypher, params = gen.generate_sync_query(ep, [evil_record])
+    cypher, _params = gen.generate_sync_query(ep, [evil_record])
     # Evil string must NOT appear in the Cypher itself
     assert "DETACH DELETE" not in cypher
     assert "'; MATCH" not in cypher
 
 
 def test_gate_compiler_never_interpolates_values():
-    """GateCompiler must emit $param refs — never interpolate values into Cypher."""
-    from engine.gates.compiler import GateCompiler
-    from engine.config.loader import DomainPackLoader
+    """GateCompiler must emit $param refs - never interpolate values into Cypher."""
     from pathlib import Path
+
+    from engine.config.loader import DomainPackLoader
+    from engine.gates.compiler import GateCompiler
+
     evil_value = "'; DROP DATABASE neo4j; //"
-    loader = DomainPackLoader(
-        domains_dir=Path(__file__).parent.parent.parent / "domains"
-    )
+    loader = DomainPackLoader(domains_dir=Path(__file__).parent.parent.parent / "domains")
     spec = loader.load_domain("plasticos")
     compiler = GateCompiler(spec)
     # Compile with evil value as parameter — it must not appear in Cypher text
@@ -68,8 +70,9 @@ def test_gate_compiler_never_interpolates_values():
 def test_eval_exec_not_importable_from_engine():
     """Engine modules must not expose eval/exec at module level."""
     import engine.gates.compiler as gc
-    import engine.sync.generator as sg
     import engine.scoring.assembler as sa
+    import engine.sync.generator as sg
+
     for mod in (gc, sg, sa):
         assert not hasattr(mod, "__builtins__") or True  # builtins always exist
         # Verify no custom eval-wrapper in public API

--- a/tests/test_algorithmic_upgrades.py
+++ b/tests/test_algorithmic_upgrades.py
@@ -6,25 +6,23 @@ Tests for the algorithmic upgrade PR:
   - engine/security/P2_9_llm_schemas.py (unit-level, no LLM)
   - chassis/audit.py (PostgresSink, LogSink)
 """
+
 from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import os
-from datetime import UTC, datetime
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-# ── Diagnostics: Fingerprint ─────────────────────────────────
+from chassis.audit import AuditAction, AuditEntry, AuditLogger, LogSink, PostgresSink
+from engine.diagnostics.dissimilarity import chi_squared_dissimilarity, detect_drift
+from engine.diagnostics.fingerprint import DEFAULT_BUCKET_LABELS, AlgorithmicFingerprint, compute_fingerprint
+from engine.packet.packet_store import PacketStore
+from engine.security.P2_9_llm_schemas import CypherQueryOutput, ValidatedLLMClient, validate_llm_json
 
-from engine.diagnostics.fingerprint import (
-    AlgorithmicFingerprint,
-    compute_fingerprint,
-    DEFAULT_BUCKET_LABELS,
-)
+# ── Diagnostics: Fingerprint ─────────────────────────────────
 
 
 class TestComputeFingerprint:
@@ -74,7 +72,8 @@ class TestComputeFingerprint:
 
     def test_to_vector(self):
         fp = compute_fingerprint(
-            "p1", "w1",
+            "p1",
+            "w1",
             [{"total_score": 0.5, "dimension_scores": {"a": 0.5, "b": 0.3}}],
         )
         vec = fp.to_vector()
@@ -99,19 +98,15 @@ class TestComputeFingerprint:
     def test_bucket_boundary_validation(self):
         with pytest.raises(ValueError, match="bucket_boundaries"):
             compute_fingerprint(
-                "p1", "w1", [{"total_score": 0.5}],
+                "p1",
+                "w1",
+                [{"total_score": 0.5}],
                 bucket_boundaries=(0.0, 1.0),
                 bucket_labels=("low", "mid", "high"),
             )
 
 
 # ── Diagnostics: Dissimilarity ───────────────────────────────
-
-from engine.diagnostics.dissimilarity import (
-    chi_squared_dissimilarity,
-    detect_drift,
-    DriftReport,
-)
 
 
 class TestChiSquaredDissimilarity:
@@ -141,7 +136,9 @@ class TestChiSquaredDissimilarity:
 
 
 class TestDetectDrift:
-    def _make_fp(self, persona_id: str, window_id: str, score_dist: dict, dim_dom: dict, entropy: float, concentration: float):
+    def _make_fp(
+        self, persona_id: str, window_id: str, score_dist: dict, dim_dom: dict, entropy: float, concentration: float
+    ):
         return AlgorithmicFingerprint(
             persona_id=persona_id,
             window_id=window_id,
@@ -193,8 +190,6 @@ class TestDetectDrift:
 
 # ── PacketStore (unit-level, no DB) ──────────────────────────
 
-from engine.packet.packet_store import PacketStore, _extract_packet_row
-
 
 class TestPacketStoreDisabled:
     """Test PacketStore behavior when PACKET_STORE_ENABLED=false (default)."""
@@ -202,28 +197,22 @@ class TestPacketStoreDisabled:
     def test_persist_is_noop_when_disabled(self):
         store = PacketStore()
         # Should not raise, just log debug
-        asyncio.get_event_loop().run_until_complete(
-            store.persist(MagicMock(), MagicMock())
-        )
+        asyncio.get_event_loop().run_until_complete(store.persist(MagicMock(), MagicMock()))
 
 
 # ── LLM Client (unit-level, no LLM) ─────────────────────────
 
-from engine.security.P2_9_llm_schemas import (
-    ValidatedLLMClient,
-    CypherQueryOutput,
-    validate_llm_json,
-)
-
 
 class TestValidateLlmJson:
     def test_valid_json(self):
-        raw = json.dumps({
-            "cypher_query": "MATCH (n) RETURN n LIMIT 10",
-            "parameters": {},
-            "explanation": "Returns first 10 nodes",
-            "confidence": 0.9,
-        })
+        raw = json.dumps(
+            {
+                "cypher_query": "MATCH (n) RETURN n LIMIT 10",
+                "parameters": {},
+                "explanation": "Returns first 10 nodes",
+                "confidence": 0.9,
+            }
+        )
         result = validate_llm_json(raw, CypherQueryOutput)
         assert isinstance(result, CypherQueryOutput)
         assert result.confidence == 0.9
@@ -233,12 +222,14 @@ class TestValidateLlmJson:
             validate_llm_json("not json", CypherQueryOutput)
 
     def test_destructive_cypher_rejected(self):
-        raw = json.dumps({
-            "cypher_query": "MATCH (n) DELETE n",
-            "parameters": {},
-            "explanation": "Delete all",
-            "confidence": 0.5,
-        })
+        raw = json.dumps(
+            {
+                "cypher_query": "MATCH (n) DELETE n",
+                "parameters": {},
+                "explanation": "Delete all",
+                "confidence": 0.5,
+            }
+        )
         with pytest.raises(Exception):
             validate_llm_json(raw, CypherQueryOutput)
 
@@ -251,6 +242,7 @@ class TestValidatedLLMClientNoProvider:
         env_backup = os.environ.pop("OPENAI_API_KEY", None)
         try:
             from engine.security.P2_9_llm_schemas import _LLMBackend
+
             backend = _LLMBackend()
             backend._client = None  # Force re-init
             with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
@@ -266,15 +258,6 @@ class TestValidatedLLMClientNoProvider:
 
 
 # ── Audit Sinks ──────────────────────────────────────────────
-
-from chassis.audit import (
-    AuditAction,
-    AuditEntry,
-    AuditLogger,
-    AuditSeverity,
-    LogSink,
-    PostgresSink,
-)
 
 
 class TestLogSink:

--- a/tests/test_pareto_wiring.py
+++ b/tests/test_pareto_wiring.py
@@ -5,13 +5,11 @@ Tests for Milestone 2.1 / 2.2 Pareto wiring:
 - OutcomeRecord + OutcomeHistoryStore
 - adaptive_weight_discovery
 """
+
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
-
-import pytest
-
+from datetime import UTC, datetime, timedelta
 
 # ═══════════════════════════════════════════════════════════════════════════
 #  Milestone 2.1: Schema Extension
@@ -244,7 +242,7 @@ class TestOutcomeHistoryStore:
             candidate_id="c_old",
             dimension_scores={"a": 0.5},
             was_selected=True,
-            timestamp=datetime.utcnow() - timedelta(days=100),
+            timestamp=datetime.now(UTC) - timedelta(days=100),
         )
         store.add_outcome("t1", old)
         # Add a recent outcome
@@ -360,16 +358,10 @@ class TestAdaptiveWeightDiscovery:
     def test_deterministic_with_seed(self):
         from engine.scoring.weight_discovery import adaptive_weight_discovery
 
-        history = [
-            {"dimension_scores": {"x": 0.8, "y": 0.6}, "was_selected": True}
-        ] * 10
+        history = [{"dimension_scores": {"x": 0.8, "y": 0.6}, "was_selected": True}] * 10
 
-        r1 = asyncio.get_event_loop().run_until_complete(
-            adaptive_weight_discovery(["x", "y"], history, n_samples=15)
-        )
-        r2 = asyncio.get_event_loop().run_until_complete(
-            adaptive_weight_discovery(["x", "y"], history, n_samples=15)
-        )
+        r1 = asyncio.get_event_loop().run_until_complete(adaptive_weight_discovery(["x", "y"], history, n_samples=15))
+        r2 = asyncio.get_event_loop().run_until_complete(adaptive_weight_discovery(["x", "y"], history, n_samples=15))
         assert len(r1) == len(r2)
-        for a, b in zip(r1, r2):
+        for a, b in zip(r1, r2, strict=True):
             assert a.weights == b.weights

--- a/tests/unit/test_arbitration.py
+++ b/tests/unit/test_arbitration.py
@@ -6,7 +6,6 @@ from engine.arbitration.engine import ArbitrationEngine
 from engine.arbitration.schema import ArbitrationInput
 from engine.config.loader import DomainSpecLoader
 
-
 SPEC_PATH = Path("domains/plasticos/spec.yaml")
 
 

--- a/tests/unit/test_compliance_checker.py
+++ b/tests/unit/test_compliance_checker.py
@@ -1,4 +1,5 @@
 """Unit tests — Compliance: prohibited factor enforcement."""
+
 from __future__ import annotations
 
 import pytest
@@ -6,7 +7,7 @@ import pytest
 
 def test_no_prohibited_factors_passes_all():
     from engine.compliance.prohibited_factors import ProhibitedFactorValidator
-    from engine.config.schema import DomainSpec
+
     # Use a mock domain spec with no prohibited factors
     try:
         validator = ProhibitedFactorValidator.__new__(ProhibitedFactorValidator)
@@ -18,20 +19,22 @@ def test_no_prohibited_factors_passes_all():
 
 def test_prohibited_factor_in_payload_raises():
     """Prohibited factors must be blocked at compile time, not runtime."""
-    from engine.compliance.prohibited_factors import ProhibitedFactorValidator
     from pathlib import Path
+
+    from engine.compliance.prohibited_factors import ProhibitedFactorValidator
     from engine.config.loader import DomainPackLoader
-    loader = DomainPackLoader(
-        domains_dir=Path(__file__).parent.parent.parent / "domains"
-    )
+
+    loader = DomainPackLoader(domains_dir=Path(__file__).parent.parent.parent / "domains")
     spec = loader.load_domain("plasticos")
     validator = ProhibitedFactorValidator(spec)
     # Validate that validate_gate doesn't silently allow prohibited fields
     if not spec.compliance or not spec.compliance.prohibited_factors:
         pytest.skip("No prohibited factors configured in plasticos spec")
-    prohibited = spec.compliance.prohibited_factors.factors[0] if hasattr(
-        spec.compliance.prohibited_factors, "factors"
-    ) else None
+    prohibited = (
+        spec.compliance.prohibited_factors.factors[0]
+        if hasattr(spec.compliance.prohibited_factors, "factors")
+        else None
+    )
     if prohibited is None:
         pytest.skip("Cannot determine prohibited factor structure")
     # The validator should raise if a gate uses a prohibited factor
@@ -40,12 +43,12 @@ def test_prohibited_factor_in_payload_raises():
 
 def test_compliance_pass_with_clean_payload():
     """Clean payload passes compliance check."""
-    from engine.compliance.engine import ComplianceEngine
     from pathlib import Path
+
+    from engine.compliance.engine import ComplianceEngine
     from engine.config.loader import DomainPackLoader
-    loader = DomainPackLoader(
-        domains_dir=Path(__file__).parent.parent.parent / "domains"
-    )
+
+    loader = DomainPackLoader(domains_dir=Path(__file__).parent.parent.parent / "domains")
     spec = loader.load_domain("plasticos")
     engine = ComplianceEngine(spec)
     result = engine.evaluate({"entity_id": "test-1", "contamination_tolerance": 0.05})

--- a/tests/unit/test_cross_dimensional_ensemble.py
+++ b/tests/unit/test_cross_dimensional_ensemble.py
@@ -25,7 +25,6 @@ import pytest
 
 from engine.kge.cross_dimensional_ensemble import (
     CrossDimensionalEnsemble,
-    CrossDimensionalResult,
     DimensionalScore,
 )
 

--- a/tests/unit/test_cypher_utils.py
+++ b/tests/unit/test_cypher_utils.py
@@ -1,4 +1,5 @@
 """Unit tests — Cypher utility functions."""
+
 from __future__ import annotations
 
 import pytest
@@ -6,35 +7,41 @@ import pytest
 
 def test_sanitize_label_accepts_valid():
     from engine.utils.security import sanitize_label
+
     assert sanitize_label("Facility") == "Facility"
     assert sanitize_label("PolymerFamily") == "PolymerFamily"
 
 
 def test_sanitize_label_rejects_spaces():
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label("bad label")
 
 
 def test_sanitize_label_rejects_empty():
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label("")
 
 
 def test_sanitize_label_rejects_sql_injection():
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label("'; DROP TABLE")
 
 
 def test_sanitize_label_rejects_numeric_start():
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label("123Label")
 
 
 def test_sanitize_label_rejects_too_long():
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label("A" * 200)

--- a/tests/unit/test_domain_loader.py
+++ b/tests/unit/test_domain_loader.py
@@ -1,10 +1,10 @@
 """Unit tests — DomainPackLoader. No Neo4j required."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
-import yaml
 
 # RULE 9: absolute path — same pattern used in conftest.py
 DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
@@ -13,6 +13,7 @@ DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 def test_load_plasticos_returns_domain_spec():
     from engine.config.loader import DomainPackLoader
     from engine.config.schema import DomainSpec
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     assert isinstance(spec, DomainSpec)
@@ -21,6 +22,7 @@ def test_load_plasticos_returns_domain_spec():
 
 def test_load_caches_second_call():
     from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec1 = loader.load_domain("plasticos")
     spec2 = loader.load_domain("plasticos")
@@ -29,6 +31,7 @@ def test_load_caches_second_call():
 
 def test_invalidate_clears_cache():
     from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec1 = loader.load_domain("plasticos")
     loader.invalidate("plasticos")
@@ -38,12 +41,14 @@ def test_invalidate_clears_cache():
 
 def test_list_domains_includes_plasticos():
     from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     assert "plasticos" in loader.list_domains()
 
 
 def test_missing_domain_raises():
     from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     with pytest.raises(Exception, match="nonexistent"):
         loader.load_domain("nonexistent")
@@ -53,6 +58,7 @@ def test_malformed_yaml_raises(tmp_path):
     bad = tmp_path / "broken.yaml"
     bad.write_text("domain:\n  id: [unclosed")
     from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=tmp_path)
     with pytest.raises(Exception):
         loader.load_domain("broken")
@@ -60,5 +66,6 @@ def test_malformed_yaml_raises(tmp_path):
 
 def test_empty_domains_dir_returns_empty_list(tmp_path):
     from engine.config.loader import DomainPackLoader
+
     loader = DomainPackLoader(domains_dir=tmp_path)
     assert loader.list_domains() == []

--- a/tests/unit/test_edge_merger.py
+++ b/tests/unit/test_edge_merger.py
@@ -22,7 +22,6 @@ import pytest
 from engine.traversal.edge_merger import (
     EdgeMerger,
     EdgeTriplet,
-    MergedEdge,
     MergeResult,
 )
 
@@ -215,14 +214,8 @@ class TestEdgeMerger:
         """Number of edges should not exceed density limit."""
         merger = EdgeMerger(density_factor=0.1)
         # Create many triplets
-        outgoing = [
-            _make_triplet(f"s{i}", f"Q_out_{i}", frozenset({f"k{i}"}), [float(i) / 10, 0.5])
-            for i in range(20)
-        ]
-        incoming = [
-            _make_triplet(f"t{i}", f"Q_in_{i}", frozenset({f"k{i}"}), [0.5, float(i) / 10])
-            for i in range(20)
-        ]
+        outgoing = [_make_triplet(f"s{i}", f"Q_out_{i}", frozenset({f"k{i}"}), [float(i) / 10, 0.5]) for i in range(20)]
+        incoming = [_make_triplet(f"t{i}", f"Q_in_{i}", frozenset({f"k{i}"}), [0.5, float(i) / 10]) for i in range(20)]
         result = merger.merge_edges(outgoing, incoming, vertex_count=40)
         density_limit = merger.compute_density_limit(40)
         assert len(result.edges) <= density_limit

--- a/tests/unit/test_gate_compiler.py
+++ b/tests/unit/test_gate_compiler.py
@@ -1,13 +1,15 @@
 """Unit tests — GateCompiler: gate types, null semantics, direction filter."""
+
 from __future__ import annotations
 
 import pytest
 
 
 def test_exact_gate_generates_equality_clause():
+    from engine.config.schema import GateSpec
     from engine.gates.compiler import GateCompiler
     from engine.gates.types.all_gates import GateType
-    from engine.config.schema import GateSpec
+
     gate = GateSpec(name="g", type=GateType.exact, field="status", query_param="status")
     result = GateCompiler._compile_single(gate, direction="*")
     assert "$status" in result or "status" in result
@@ -15,14 +17,18 @@ def test_exact_gate_generates_equality_clause():
 
 def test_direction_filter_skips_non_matching():
     """A gate scoped to buyer_to_seller must not compile for seller_to_buyer."""
+    from engine.config.schema import GateSpec
     from engine.gates.compiler import GateCompiler
     from engine.gates.types.all_gates import GateType
-    from engine.config.schema import GateSpec
+
     # If gate has match_direction kwarg — test skipping
     # This is a structural test — verify compiler produces no clause for wrong direction
     try:
         gate = GateSpec(
-            name="g", type=GateType.exact, field="f", query_param="f",
+            name="g",
+            type=GateType.exact,
+            field="f",
+            query_param="f",
             match_direction="buyer_to_seller",
         )
         result = GateCompiler._compile_single(gate, direction="seller_to_buyer")
@@ -33,13 +39,17 @@ def test_direction_filter_skips_non_matching():
 
 def test_null_behavior_pass_wraps_clause():
     """null_behavior=pass should wrap clause with IS NULL OR condition."""
+    from engine.config.schema import GateSpec
     from engine.gates.compiler import GateCompiler
     from engine.gates.types.all_gates import GateType
-    from engine.config.schema import GateSpec
+
     try:
         gate = GateSpec(
-            name="g", type=GateType.exact, field="status",
-            query_param="status", null_behavior="pass",
+            name="g",
+            type=GateType.exact,
+            field="status",
+            query_param="status",
+            null_behavior="pass",
         )
         result = GateCompiler._compile_single(gate, direction="*")
         assert "NULL" in result or "$status" in result
@@ -48,10 +58,11 @@ def test_null_behavior_pass_wraps_clause():
 
 
 def test_compile_all_gates_empty_returns_empty():
-    from engine.gates.compiler import GateCompiler
-    from engine.config.schema import DomainSpec
-    from engine.config.loader import DomainPackLoader
     from pathlib import Path
+
+    from engine.config.loader import DomainPackLoader
+    from engine.gates.compiler import GateCompiler
+
     loader = DomainPackLoader(domains_dir=Path(__file__).parent.parent.parent / "domains")
     spec = loader.load_domain("plasticos")
     compiler = GateCompiler(spec)

--- a/tests/unit/test_handlers_enrich_health.py
+++ b/tests/unit/test_handlers_enrich_health.py
@@ -179,7 +179,7 @@ class TestHandleHealthcheck:
         """handle_healthcheck should return health status dict."""
         from unittest.mock import AsyncMock, MagicMock
 
-        from engine.state import get_state, _reset_singleton
+        from engine.state import _reset_singleton, get_state
 
         _reset_singleton()
         mock_driver = MagicMock()
@@ -213,7 +213,7 @@ class TestHandleEnrich:
         """handle_enrich should require entity_type in payload."""
         from unittest.mock import MagicMock
 
-        from engine.state import get_state, _reset_singleton
+        from engine.state import _reset_singleton, get_state
 
         _reset_singleton()
         mock_driver = MagicMock()
@@ -237,7 +237,7 @@ class TestHandleEnrich:
         """handle_enrich should return 0 count for empty enrichments."""
         from unittest.mock import MagicMock
 
-        from engine.state import get_state, _reset_singleton
+        from engine.state import _reset_singleton, get_state
 
         _reset_singleton()
         mock_driver = MagicMock()
@@ -269,7 +269,7 @@ class TestHandleEnrich:
         """handle_enrich should validate expressions before execution."""
         from unittest.mock import MagicMock
 
-        from engine.state import get_state, _reset_singleton
+        from engine.state import _reset_singleton, get_state
 
         _reset_singleton()
         mock_driver = MagicMock()
@@ -301,7 +301,7 @@ class TestHandleEnrich:
         """handle_enrich should execute valid enrichments."""
         from unittest.mock import AsyncMock, MagicMock
 
-        from engine.state import get_state, _reset_singleton
+        from engine.state import _reset_singleton, get_state
 
         _reset_singleton()
         mock_driver = MagicMock()

--- a/tests/unit/test_handlers_extended.py
+++ b/tests/unit/test_handlers_extended.py
@@ -21,8 +21,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from engine.state import get_state, _reset_singleton
-
 from engine.handlers import (
     EngineError,
     ExecutionError,
@@ -35,6 +33,7 @@ from engine.handlers import (
     init_dependencies,
     register_all,
 )
+from engine.state import _reset_singleton, get_state
 
 # ============================================================================
 # FIXTURES

--- a/tests/unit/test_hgkr_gds_dag.py
+++ b/tests/unit/test_hgkr_gds_dag.py
@@ -22,7 +22,6 @@ Reference:
 from __future__ import annotations
 
 import pytest
-from unittest.mock import MagicMock
 
 from engine.config.schema import GDSJobScheduleSpec, GDSJobSpec, GDSProjectionSpec
 from engine.gds.scheduler import GDSScheduler

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -4,7 +4,6 @@ import pytest
 
 from engine.config.loader import DomainSpecLoader
 
-
 SPEC_PATH = Path("domains/plasticos/spec.yaml")
 
 

--- a/tests/unit/test_multihop_traversal.py
+++ b/tests/unit/test_multihop_traversal.py
@@ -14,7 +14,6 @@ Unit tests for engine.traversal.multihop module.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import numpy as np

--- a/tests/unit/test_outcomes.py
+++ b/tests/unit/test_outcomes.py
@@ -1,12 +1,11 @@
-from pathlib import Path
 import asyncio
+from pathlib import Path
 
 from engine.config.loader import DomainSpecLoader
 from engine.graph.driver import GraphDriver
 from engine.outcomes.engine import OutcomeEngine
 from engine.outcomes.schema import OutcomeEvent
 from engine.scoring.assembler import ScoringAssembler
-
 
 SPEC_PATH = Path("domains/plasticos/spec.yaml")
 

--- a/tests/unit/test_packet_bridge.py
+++ b/tests/unit/test_packet_bridge.py
@@ -1,10 +1,13 @@
 """Unit tests — PacketEnvelope bridge: hash determinism, payload sensitivity."""
+
 from __future__ import annotations
 
 
 def test_packet_envelope_content_hash_is_deterministic():
-    from engine.packet.packet_envelope import PacketEnvelope, PacketType, Action
     from engine.chassis.tenant_context import TenantContext
+
+    from engine.packet.packet_envelope import PacketEnvelope, PacketType
+
     tenant = TenantContext(tenant_id="test", actor="unit-test")
     p1 = PacketEnvelope(
         packet_type=PacketType.REQUEST,
@@ -21,8 +24,10 @@ def test_packet_envelope_content_hash_is_deterministic():
 
 
 def test_packet_envelope_hash_changes_with_payload():
-    from engine.packet.packet_envelope import PacketEnvelope, PacketType
     from engine.chassis.tenant_context import TenantContext
+
+    from engine.packet.packet_envelope import PacketEnvelope, PacketType
+
     tenant = TenantContext(tenant_id="test", actor="unit-test")
     p1 = PacketEnvelope(
         packet_type=PacketType.REQUEST,
@@ -39,6 +44,7 @@ def test_packet_envelope_hash_changes_with_payload():
 
 def test_packet_bridge_inflate_ingress():
     from engine.packet.bridge import PacketBridge
+
     bridge = PacketBridge()
     packet = bridge.inflate_ingress(
         tenant_id="tenant-a",
@@ -53,6 +59,7 @@ def test_packet_bridge_inflate_ingress():
 
 def test_packet_bridge_derive_preserves_lineage():
     from engine.packet.bridge import PacketBridge
+
     bridge = PacketBridge()
     root = bridge.inflate_ingress(
         tenant_id="tenant-a",

--- a/tests/unit/test_parameter_resolver.py
+++ b/tests/unit/test_parameter_resolver.py
@@ -1,7 +1,7 @@
 """Unit tests — Parameter coercion: range floats, booleans, set lists, None exclusion."""
+
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
 
 DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
@@ -11,6 +11,7 @@ def test_none_values_excluded_from_params():
     """None values must never reach Cypher parameters."""
     from engine.config.loader import DomainPackLoader
     from engine.traversal.resolver import ParameterResolver
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     resolver = ParameterResolver(spec)
@@ -22,6 +23,7 @@ def test_none_values_excluded_from_params():
 def test_string_passthrough():
     from engine.config.loader import DomainPackLoader
     from engine.traversal.resolver import ParameterResolver
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     resolver = ParameterResolver(spec)
@@ -32,6 +34,7 @@ def test_string_passthrough():
 def test_empty_params_returns_empty():
     from engine.config.loader import DomainPackLoader
     from engine.traversal.resolver import ParameterResolver
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     resolver = ParameterResolver(spec)

--- a/tests/unit/test_persona_composer.py
+++ b/tests/unit/test_persona_composer.py
@@ -153,10 +153,12 @@ class TestBlendPersonas:
         p1 = _make_persona("p1", analytical_depth=0.8, creativity=0.2)
         p2 = _make_persona("p2", analytical_depth=0.4, creativity=0.6)
 
-        result = blend_personas([
-            {"persona": p1, "weight": 1.0},
-            {"persona": p2, "weight": 1.0},
-        ])
+        result = blend_personas(
+            [
+                {"persona": p1, "weight": 1.0},
+                {"persona": p2, "weight": 1.0},
+            ]
+        )
 
         assert result.analytical_depth == pytest.approx(0.6)
         assert result.creativity == pytest.approx(0.4)
@@ -166,10 +168,12 @@ class TestBlendPersonas:
         p1 = _make_persona("p1", precision=1.0)
         p2 = _make_persona("p2", precision=0.0)
 
-        result = blend_personas([
-            {"persona": p1, "weight": 3.0},
-            {"persona": p2, "weight": 1.0},
-        ])
+        result = blend_personas(
+            [
+                {"persona": p1, "weight": 3.0},
+                {"persona": p2, "weight": 1.0},
+            ]
+        )
 
         assert result.precision == pytest.approx(0.75)
 
@@ -199,10 +203,12 @@ class TestBlendPersonas:
         p1 = _make_persona("p1", analytical_depth=1.0, creativity=1.0)
         p2 = _make_persona("p2", analytical_depth=1.0, creativity=1.0)
 
-        result = blend_personas([
-            {"persona": p1, "weight": 5.0},
-            {"persona": p2, "weight": 5.0},
-        ])
+        result = blend_personas(
+            [
+                {"persona": p1, "weight": 5.0},
+                {"persona": p2, "weight": 5.0},
+            ]
+        )
 
         for dim in result.dimensions():
             val = getattr(result, dim)
@@ -239,10 +245,13 @@ class TestCreateCompositePersona:
         p2 = _make_persona("p2", forbidden=["overconfidence", "speculation"])
 
         fv = FeatureVector()
-        composite = create_composite_persona(fv, [
-            {"persona": p1, "score": 0.5},
-            {"persona": p2, "score": 0.3},
-        ])
+        composite = create_composite_persona(
+            fv,
+            [
+                {"persona": p1, "score": 0.5},
+                {"persona": p2, "score": 0.3},
+            ],
+        )
 
         assert "speculation" in composite.forbidden_behaviors
         assert "hedging" in composite.forbidden_behaviors
@@ -256,10 +265,13 @@ class TestCreateCompositePersona:
         p2 = _make_persona("p2", analytical_depth=0.0, creativity=1.0)
 
         fv = FeatureVector(analytical_depth=0.5, creativity=0.5)
-        composite = create_composite_persona(fv, [
-            {"persona": p1, "score": 0.6},
-            {"persona": p2, "score": 0.4},
-        ])
+        composite = create_composite_persona(
+            fv,
+            [
+                {"persona": p1, "score": 0.6},
+                {"persona": p2, "score": 0.4},
+            ],
+        )
 
         # Weighted: (0.6*1.0 + 0.4*0.0) / 1.0 = 0.6
         assert composite.trait_vector.analytical_depth == pytest.approx(0.6)
@@ -272,10 +284,13 @@ class TestCreateCompositePersona:
         p2 = _make_persona("p2", "Creative", system_prompt="Think creatively.")
 
         fv = FeatureVector(analytical_depth=0.8, creativity=0.8)
-        composite = create_composite_persona(fv, [
-            {"persona": p1, "score": 0.6},
-            {"persona": p2, "score": 0.4},
-        ])
+        composite = create_composite_persona(
+            fv,
+            [
+                {"persona": p1, "score": 0.6},
+                {"persona": p2, "score": 0.4},
+            ],
+        )
 
         assert "Analyst" in composite.system_prompt
         assert "Creative" in composite.system_prompt
@@ -292,10 +307,13 @@ class TestCreateCompositePersona:
         p2 = _make_persona("beta")
 
         fv = FeatureVector()
-        composite = create_composite_persona(fv, [
-            {"persona": p1, "score": 0.5},
-            {"persona": p2, "score": 0.3},
-        ])
+        composite = create_composite_persona(
+            fv,
+            [
+                {"persona": p1, "score": 0.5},
+                {"persona": p2, "score": 0.3},
+            ],
+        )
 
         assert composite.id.startswith("composite_")
         assert "alpha" in composite.id

--- a/tests/unit/test_persona_selector.py
+++ b/tests/unit/test_persona_selector.py
@@ -127,10 +127,7 @@ class TestSelectPersonas:
 
     def test_max_personas_limit(self) -> None:
         """Selection never exceeds max_personas (3)."""
-        personas = [
-            _make_persona(f"p{i}", f"P{i}", analytical_depth=0.9 - i * 0.01)
-            for i in range(5)
-        ]
+        personas = [_make_persona(f"p{i}", f"P{i}", analytical_depth=0.9 - i * 0.01) for i in range(5)]
 
         fv = FeatureVector(analytical_depth=1.0)
         active = select_personas(fv, personas)

--- a/tests/unit/test_persona_synthesis.py
+++ b/tests/unit/test_persona_synthesis.py
@@ -69,7 +69,8 @@ class TestComputePrimitiveAlignment:
     def test_multi_primitive_alignment(self) -> None:
         """Alignment across multiple primitive dimensions."""
         output = _make_output(
-            "p1", "Multi",
+            "p1",
+            "Multi",
             verification_need=0.8,
             comparison_need=0.6,
             generation_need=0.4,

--- a/tests/unit/test_sanitize.py
+++ b/tests/unit/test_sanitize.py
@@ -1,4 +1,5 @@
 """Unit tests — sanitize_label / sanitize_property / sanitize_relationship."""
+
 from __future__ import annotations
 
 import pytest
@@ -7,25 +8,37 @@ import pytest
 @pytest.mark.parametrize("value", ["Facility", "LoanProduct", "A1b2C3"])
 def test_valid_labels(value):
     from engine.utils.security import sanitize_label
+
     assert sanitize_label(value) == value
 
 
-@pytest.mark.parametrize("value", [
-    "'; DROP TABLE", "123start", "", "has space", "a" * 65,
-    "__class__", "None",
-])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "'; DROP TABLE",
+        "123start",
+        "",
+        "has space",
+        "a" * 65,
+        "__class__",
+        "None",
+    ],
+)
 def test_invalid_labels_raise(value):
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label(value)
 
 
 def test_valid_property():
     from engine.utils.security import sanitize_label
+
     assert sanitize_label("ContaminationTolerance") == "ContaminationTolerance"
 
 
 def test_invalid_property_raises():
     from engine.utils.security import sanitize_label
+
     with pytest.raises((ValueError, Exception)):
         sanitize_label("bad prop!")

--- a/tests/unit/test_scoring_assembler.py
+++ b/tests/unit/test_scoring_assembler.py
@@ -1,8 +1,10 @@
 """Unit tests — ScoringAssembler: scoring types, weight override, aggregation."""
+
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 
@@ -10,6 +12,7 @@ DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 def test_assembler_loads_from_plasticos_spec():
     from engine.config.loader import DomainPackLoader
     from engine.scoring.assembler import ScoringAssembler
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     assembler = ScoringAssembler(spec)
@@ -20,8 +23,9 @@ def test_assembler_loads_from_plasticos_spec():
 
 def test_empty_dims_returns_default_score():
     """With no scoring dimensions, assembler should return a safe default."""
-    from engine.scoring.assembler import ScoringAssembler
     from engine.config.schema import DomainSpec
+    from engine.scoring.assembler import ScoringAssembler
+
     raw = {
         "domain": {"id": "test", "name": "Test", "version": "0.0.1"},
         "ontology": {"nodes": [], "edges": []},
@@ -43,6 +47,7 @@ def test_empty_dims_returns_default_score():
 def test_scoring_clause_contains_composite_score():
     from engine.config.loader import DomainPackLoader
     from engine.scoring.assembler import ScoringAssembler
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     assembler = ScoringAssembler(spec)
@@ -54,6 +59,7 @@ def test_scoring_clause_contains_composite_score():
 def test_weight_override_changes_output():
     from engine.config.loader import DomainPackLoader
     from engine.scoring.assembler import ScoringAssembler
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     assembler = ScoringAssembler(spec)

--- a/tests/unit/test_sync_and_traversal.py
+++ b/tests/unit/test_sync_and_traversal.py
@@ -4,7 +4,6 @@ from engine.config.loader import DomainSpecLoader
 from engine.sync.generator import SyncGenerator
 from engine.traversal.assembler import TraversalAssembler
 
-
 SPEC_PATH = Path("domains/plasticos/spec.yaml")
 
 

--- a/tests/unit/test_sync_generator.py
+++ b/tests/unit/test_sync_generator.py
@@ -1,8 +1,10 @@
-"""Unit tests — SyncGenerator: MERGE strategy, unknown strategy/endpoint."""
+"""Unit tests - SyncGenerator: MERGE strategy, unknown strategy/endpoint."""
+
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 
@@ -10,6 +12,7 @@ DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 def test_sync_generator_produces_merge_cypher():
     from engine.config.loader import DomainPackLoader
     from engine.sync.generator import SyncGenerator
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     gen = SyncGenerator(spec)
@@ -17,7 +20,7 @@ def test_sync_generator_produces_merge_cypher():
     if not spec.sync.endpoints:
         pytest.skip("No sync endpoints in plasticos spec")
     ep = spec.sync.endpoints[0]
-    cypher, params = gen.generate_sync_query(ep, [{"id": "test-1", "name": "Alpha"}])
+    cypher, _params = gen.generate_sync_query(ep, [{"id": "test-1", "name": "Alpha"}])
     assert "MERGE" in cypher or "MATCH" in cypher
     assert "UNWIND" in cypher or "$" in cypher
 
@@ -25,19 +28,21 @@ def test_sync_generator_produces_merge_cypher():
 def test_sync_generator_includes_batch_param():
     from engine.config.loader import DomainPackLoader
     from engine.sync.generator import SyncGenerator
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     gen = SyncGenerator(spec)
     if not spec.sync.endpoints:
         pytest.skip("No sync endpoints in plasticos spec")
     ep = spec.sync.endpoints[0]
-    cypher, params = gen.generate_sync_query(ep, [{"entity_id": "f1"}])
+    _cypher, params = gen.generate_sync_query(ep, [{"entity_id": "f1"}])
     assert "batch" in params or len(params) > 0
 
 
 def test_unknown_entity_raises():
     from engine.config.loader import DomainPackLoader
     from engine.sync.generator import SyncGenerator
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     gen = SyncGenerator(spec)

--- a/tests/unit/test_traversal_assembler.py
+++ b/tests/unit/test_traversal_assembler.py
@@ -1,7 +1,7 @@
 """Unit tests — TraversalAssembler: direction filter, step ordering."""
+
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
 
 DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
@@ -10,6 +10,7 @@ DOMAINS_DIR = Path(__file__).parent.parent.parent / "domains"
 def test_assembler_produces_list():
     from engine.config.loader import DomainPackLoader
     from engine.traversal.assembler import TraversalAssembler
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     assembler = TraversalAssembler(spec)
@@ -21,7 +22,7 @@ def test_wildcard_direction_always_included():
     """Steps with direction='*' must appear regardless of query direction."""
     from engine.config.loader import DomainPackLoader
     from engine.traversal.assembler import TraversalAssembler
-    from engine.config.schema import TraversalStepSpec
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     # Check that traversal has at least the spec's own steps
@@ -36,6 +37,7 @@ def test_wildcard_direction_always_included():
 def test_traversal_steps_are_strings():
     from engine.config.loader import DomainPackLoader
     from engine.traversal.assembler import TraversalAssembler
+
     loader = DomainPackLoader(domains_dir=DOMAINS_DIR)
     spec = loader.load_domain("plasticos")
     assembler = TraversalAssembler(spec)

--- a/tests/unit/test_wave4_state_resilience.py
+++ b/tests/unit/test_wave4_state_resilience.py
@@ -447,16 +447,16 @@ class TestComplianceEngineSingleton:
 
         spec = self._make_domain_spec()
 
-        with patch("engine.handlers.ComplianceEngine") as MockCE:
+        with patch("engine.handlers.ComplianceEngine") as mock_ce_cls:
             mock_ce = MagicMock()
-            MockCE.return_value = mock_ce
+            mock_ce_cls.return_value = mock_ce
 
             ce1 = _get_compliance_engine(spec)
             ce2 = _get_compliance_engine(spec)
 
             assert ce1 is ce2
             # Should only be created once
-            MockCE.assert_called_once()
+            mock_ce_cls.assert_called_once()
 
     def test_different_domains_get_different_engines(self) -> None:
         from engine.handlers import _get_compliance_engine
@@ -468,14 +468,14 @@ class TestComplianceEngineSingleton:
         spec_a = self._make_domain_spec("domain_a")
         spec_b = self._make_domain_spec("domain_b")
 
-        with patch("engine.handlers.ComplianceEngine") as MockCE:
-            MockCE.side_effect = [MagicMock(), MagicMock()]
+        with patch("engine.handlers.ComplianceEngine") as mock_ce_cls:
+            mock_ce_cls.side_effect = [MagicMock(), MagicMock()]
 
             ce_a = _get_compliance_engine(spec_a)
             ce_b = _get_compliance_engine(spec_b)
 
             assert ce_a is not ce_b
-            assert MockCE.call_count == 2
+            assert mock_ce_cls.call_count == 2
 
     @pytest.mark.asyncio
     async def test_shutdown_clears_compliance_pool(self) -> None:
@@ -578,7 +578,6 @@ class TestHandlersUseEngineState:
 
     def test_require_deps_uses_engine_state(self) -> None:
         from engine.handlers import _require_deps, init_dependencies
-        from engine.state import get_state
 
         mock_driver = MagicMock()
         mock_loader = MagicMock()

--- a/tests/unit/test_wave6_dormant_features.py
+++ b/tests/unit/test_wave6_dormant_features.py
@@ -23,7 +23,6 @@ import pytest
 
 from engine.handlers import handle_admin, init_dependencies
 
-
 # ── Fixtures ────────────────────────────────────────────────
 
 

--- a/tools/contract_report.py
+++ b/tools/contract_report.py
@@ -23,7 +23,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -92,26 +91,30 @@ def generate_report(contracts: list[dict], repo_root: Path) -> list[dict]:
         has_scanner = check_scanner_rules(c, scanner_path)
         tests = check_test_exists(c, repo_root)
 
-        coverage_count = sum([
-            has_scanner,
-            tests["unit"],
-            tests["contract"],
-            tests["integration"],
-            tests["property"],
-        ])
+        coverage_count = sum(
+            [
+                has_scanner,
+                tests["unit"],
+                tests["contract"],
+                tests["integration"],
+                tests["property"],
+            ]
+        )
 
-        rows.append({
-            "id": cid,
-            "name": name,
-            "layer": layer,
-            "level": level,
-            "scanner": "✓" if has_scanner else "—",
-            "unit_test": "✓" if tests["unit"] else "—",
-            "contract_test": "✓" if tests["contract"] else "—",
-            "integration_test": "✓" if tests["integration"] else "—",
-            "property_test": "✓" if tests["property"] else "—",
-            "coverage": f"{coverage_count}/5",
-        })
+        rows.append(
+            {
+                "id": cid,
+                "name": name,
+                "layer": layer,
+                "level": level,
+                "scanner": "✓" if has_scanner else "—",
+                "unit_test": "✓" if tests["unit"] else "—",
+                "contract_test": "✓" if tests["contract"] else "—",
+                "integration_test": "✓" if tests["integration"] else "—",
+                "property_test": "✓" if tests["property"] else "—",
+                "coverage": f"{coverage_count}/5",
+            }
+        )
 
     return rows
 

--- a/tools/hoprag_benchmark.py
+++ b/tools/hoprag_benchmark.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -109,11 +108,7 @@ def compute_retrieval_metrics(
     true_positives = len(retrieved_set & relevant_set)
     precision = true_positives / len(retrieved_set) if retrieved_set else 0.0
     recall = true_positives / len(relevant_set) if relevant_set else 0.0
-    f1 = (
-        2 * precision * recall / (precision + recall)
-        if (precision + recall) > 0
-        else 0.0
-    )
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
 
     return RetrievalMetrics(
         precision=precision,
@@ -159,15 +154,9 @@ def run_benchmark(
         per_query.append(metrics)
 
     num_queries = len(per_query)
-    mean_precision = (
-        sum(m.precision for m in per_query) / num_queries if num_queries else 0.0
-    )
-    mean_recall = (
-        sum(m.recall for m in per_query) / num_queries if num_queries else 0.0
-    )
-    mean_f1 = (
-        sum(m.f1 for m in per_query) / num_queries if num_queries else 0.0
-    )
+    mean_precision = sum(m.precision for m in per_query) / num_queries if num_queries else 0.0
+    mean_recall = sum(m.recall for m in per_query) / num_queries if num_queries else 0.0
+    mean_f1 = sum(m.f1 for m in per_query) / num_queries if num_queries else 0.0
 
     execution_time_s = time.monotonic() - start_time
 

--- a/tools/validate_domain.py
+++ b/tools/validate_domain.py
@@ -43,50 +43,60 @@ def _check_cross_references(spec: DomainSpec) -> list[dict]:
     # Check edge from/to references
     for edge in spec.ontology.edges:
         if edge.from_ not in node_labels:
-            results.append({
-                "check": "W1-01-edge-source",
-                "status": "FAIL",
-                "message": f"Edge '{edge.type}' source '{edge.from_}' not in ontology nodes",
-                "path": f"ontology.edges[type={edge.type}].from",
-            })
+            results.append(
+                {
+                    "check": "W1-01-edge-source",
+                    "status": "FAIL",
+                    "message": f"Edge '{edge.type}' source '{edge.from_}' not in ontology nodes",
+                    "path": f"ontology.edges[type={edge.type}].from",
+                }
+            )
         if edge.to not in node_labels:
-            results.append({
-                "check": "W1-01-edge-target",
-                "status": "FAIL",
-                "message": f"Edge '{edge.type}' target '{edge.to}' not in ontology nodes",
-                "path": f"ontology.edges[type={edge.type}].to",
-            })
+            results.append(
+                {
+                    "check": "W1-01-edge-target",
+                    "status": "FAIL",
+                    "message": f"Edge '{edge.type}' target '{edge.to}' not in ontology nodes",
+                    "path": f"ontology.edges[type={edge.type}].to",
+                }
+            )
 
     # Check match entity references
     for candidate in spec.matchentities.candidate:
         if candidate.label not in node_labels:
-            results.append({
-                "check": "W1-01-candidate-label",
-                "status": "FAIL",
-                "message": f"Candidate label '{candidate.label}' not in ontology",
-                "path": f"matchentities.candidate[label={candidate.label}]",
-            })
+            results.append(
+                {
+                    "check": "W1-01-candidate-label",
+                    "status": "FAIL",
+                    "message": f"Candidate label '{candidate.label}' not in ontology",
+                    "path": f"matchentities.candidate[label={candidate.label}]",
+                }
+            )
 
     # Check gate edge references
     for gate in spec.gates:
         if gate.edgetype and gate.edgetype not in edge_types:
-            results.append({
-                "check": "W1-01-gate-edge",
-                "status": "FAIL",
-                "message": f"Gate '{gate.name}' references unknown edge type '{gate.edgetype}'",
-                "path": f"gates[name={gate.name}].edgetype",
-            })
+            results.append(
+                {
+                    "check": "W1-01-gate-edge",
+                    "status": "FAIL",
+                    "message": f"Gate '{gate.name}' references unknown edge type '{gate.edgetype}'",
+                    "path": f"gates[name={gate.name}].edgetype",
+                }
+            )
 
     # Check scoring weight sum
     if spec.scoring and spec.scoring.dimensions:
         weight_sum = sum(d.defaultweight for d in spec.scoring.dimensions)
         if weight_sum > 1.0 + 1e-9:
-            results.append({
-                "check": "W1-01-weight-sum",
-                "status": "FAIL",
-                "message": f"Scoring default weights sum to {weight_sum:.4f}, exceeding 1.0",
-                "path": "scoring.dimensions[*].defaultweight",
-            })
+            results.append(
+                {
+                    "check": "W1-01-weight-sum",
+                    "status": "FAIL",
+                    "message": f"Scoring default weights sum to {weight_sum:.4f}, exceeding 1.0",
+                    "path": "scoring.dimensions[*].defaultweight",
+                }
+            )
 
     if not results:
         results.append({"check": "W1-01-cross-ref", "status": "PASS", "message": "All cross-references valid"})
@@ -106,17 +116,21 @@ def _check_gate_compilation(spec: DomainSpec) -> list[dict]:
         for direction in directions:
             clause = compiler.compile_all_gates(direction)
             if clause:
-                results.append({
-                    "check": "W1-03-gate-compile",
-                    "status": "PASS",
-                    "message": f"Gates compile for direction '{direction}' ({len(clause)} chars)",
-                })
+                results.append(
+                    {
+                        "check": "W1-03-gate-compile",
+                        "status": "PASS",
+                        "message": f"Gates compile for direction '{direction}' ({len(clause)} chars)",
+                    }
+                )
     except Exception as exc:
-        results.append({
-            "check": "W1-03-gate-compile",
-            "status": "FAIL",
-            "message": f"Gate compilation failed: {exc}",
-        })
+        results.append(
+            {
+                "check": "W1-03-gate-compile",
+                "status": "FAIL",
+                "message": f"Gate compilation failed: {exc}",
+            }
+        )
 
     if not results:
         results.append({"check": "W1-03-gate-compile", "status": "PASS", "message": "No gates to compile"})
@@ -142,17 +156,21 @@ def _check_traversal(spec: DomainSpec) -> list[dict]:
                 for w in warnings:
                     results.append({"check": "W1-04-traversal", "status": "WARN", "message": w})
             else:
-                results.append({
-                    "check": "W1-04-traversal",
-                    "status": "PASS",
-                    "message": f"Traversal valid for direction '{direction}'",
-                })
+                results.append(
+                    {
+                        "check": "W1-04-traversal",
+                        "status": "PASS",
+                        "message": f"Traversal valid for direction '{direction}'",
+                    }
+                )
     except Exception as exc:
-        results.append({
-            "check": "W1-04-traversal",
-            "status": "FAIL",
-            "message": f"Traversal validation failed: {exc}",
-        })
+        results.append(
+            {
+                "check": "W1-04-traversal",
+                "status": "FAIL",
+                "message": f"Traversal validation failed: {exc}",
+            }
+        )
 
     return results
 
@@ -167,17 +185,21 @@ def _check_compliance(spec: DomainSpec) -> list[dict]:
         validator = ProhibitedFactorValidator(spec)
         for gate in spec.gates:
             validator.validate_gate(gate)
-        results.append({
-            "check": "W3-02-prohibited-factors",
-            "status": "PASS",
-            "message": "No prohibited factors in gates",
-        })
+        results.append(
+            {
+                "check": "W3-02-prohibited-factors",
+                "status": "PASS",
+                "message": "No prohibited factors in gates",
+            }
+        )
     except (ValueError, Exception) as exc:
-        results.append({
-            "check": "W3-02-prohibited-factors",
-            "status": "FAIL",
-            "message": f"Prohibited factor violation: {exc}",
-        })
+        results.append(
+            {
+                "check": "W3-02-prohibited-factors",
+                "status": "FAIL",
+                "message": f"Prohibited factor violation: {exc}",
+            }
+        )
 
     return results
 


### PR DESCRIPTION
## Summary

GRAPH-side companion to EIE PR cryptoxdog/Enrichment.Inference.Engine#31.

Adds `RedisStreamAdapter` to the GRAPH repo so the graph_worker can publish
`graph.inference.complete` events after every materialization batch.
EIE's new `GraphInferenceConsumer` subscribes and feeds qualifying inferred
triples back into the convergence loop.

---

## New File

**`engine/adapters/redis_stream_adapter.py`**

- Async `RedisStreamAdapter` class wrapping `redis.asyncio`
- `publish_inference_event()` — publishes to `graph.inference.complete` stream with:
  - entity_id, domain, run_id
  - inferred_triples (list of subject/predicate/object/confidence dicts)
  - materialization_pass, graph_confidence
- Non-fatal failure path — if Redis is unavailable, EIE degrades gracefully (no GRAPH signals, loop exits normally)
- `STREAM_MAXLEN = 50_000` with approximate trim to bound memory

## Integration Point

Call `await redis_adapter.publish_inference_event(...)` in `graph_worker.py` after each materialization batch completes. Wire the adapter via `Settings.redis_url`.

## Stream Contract

```
Stream:  graph.inference.complete
Payload: {"entity_id": str, "domain": str, "run_id": str,
          "inferred_triples": [...], "materialization_pass": int,
          "graph_confidence": float}
```

## Companion PR
EIE consumer side: cryptoxdog/Enrichment.Inference.Engine#31

---
*IgorBot · 2026-04-01*